### PR TITLE
[FEAT] tag cell selected event logic 변경

### DIFF
--- a/KnockKnock-iOS/Entity/Challenge.swift
+++ b/KnockKnock-iOS/Entity/Challenge.swift
@@ -16,4 +16,14 @@ struct Challenges: Decodable {
 struct ChallengeTitle: Decodable {
   let id: Int
   let title: String
+  var isSelected: Bool
+
+  private enum CodingKeys: String, CodingKey { case id, title }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decode(Int.self, forKey: .id)
+    self.title = try container.decode(String.self, forKey: .title)
+    self.isSelected = false
+  }
 }

--- a/KnockKnock-iOS/Scenes/Cells/TagCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/TagCell.swift
@@ -15,7 +15,7 @@ class TagCell: BaseCollectionViewCell {
     $0.translatesAutoresizingMaskIntoConstraints = false
     $0.textAlignment = .center
     $0.clipsToBounds = true
-    $0.layer.cornerRadius = 20
+    $0.layer.cornerRadius = 18
     $0.textColor = .green50
     $0.layer.borderWidth = 1
     $0.layer.borderColor = UIColor.green40?.cgColor
@@ -33,13 +33,13 @@ class TagCell: BaseCollectionViewCell {
     case true:
       self.tagLabel.backgroundColor = .green50
       self.tagLabel.textColor = .white
-      self.tagLabel.font = .systemFont(ofSize: 14, weight: .bold)
+      self.tagLabel.font = .systemFont(ofSize: 13, weight: .bold)
       self.tagLabel.sizeToFit()
 
     case false:
       self.tagLabel.backgroundColor = .white
       self.tagLabel.textColor = .green50
-      self.tagLabel.font = .systemFont(ofSize: 14, weight: .medium)
+      self.tagLabel.font = .systemFont(ofSize: 13, weight: .medium)
       self.tagLabel.sizeToFit()
     }
   }

--- a/KnockKnock-iOS/Scenes/Cells/TagCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/TagCell.swift
@@ -11,11 +11,11 @@ class TagCell: BaseCollectionViewCell {
 
   // MARK: - UIs
 
-  let tagLabel = BasePaddingLabel().then {
+  private let tagLabel = BasePaddingLabel().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
     $0.textAlignment = .center
     $0.clipsToBounds = true
-    $0.layer.cornerRadius = 18
+    $0.layer.cornerRadius = 20
     $0.textColor = .green50
     $0.layer.borderWidth = 1
     $0.layer.borderColor = UIColor.green40?.cgColor
@@ -28,18 +28,18 @@ class TagCell: BaseCollectionViewCell {
     self.setLabel(isSelected: tag.isSelected)
   }
 
-  func setLabel(isSelected: Bool) {
+  private func setLabel(isSelected: Bool) {
     switch isSelected {
     case true:
       self.tagLabel.backgroundColor = .green50
       self.tagLabel.textColor = .white
-      self.tagLabel.font = .systemFont(ofSize: 13, weight: .bold)
+      self.tagLabel.font = .systemFont(ofSize: 14, weight: .bold)
       self.tagLabel.sizeToFit()
 
     case false:
       self.tagLabel.backgroundColor = .white
       self.tagLabel.textColor = .green50
-      self.tagLabel.font = .systemFont(ofSize: 13, weight: .medium)
+      self.tagLabel.font = .systemFont(ofSize: 14, weight: .medium)
       self.tagLabel.sizeToFit()
     }
   }

--- a/KnockKnock-iOS/Scenes/Cells/TagCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/TagCell.swift
@@ -23,8 +23,25 @@ class TagCell: BaseCollectionViewCell {
 
   // MARK: - Bind
 
-  func bind(tag: String) {
-    self.tagLabel.text = tag
+  func bind(tag: ChallengeTitle) {
+    self.tagLabel.text = tag.title
+    self.setLabel(isSelected: tag.isSelected)
+  }
+
+  func setLabel(isSelected: Bool) {
+    switch isSelected {
+    case true:
+      self.tagLabel.backgroundColor = .green50
+      self.tagLabel.textColor = .white
+      self.tagLabel.font = .systemFont(ofSize: 14, weight: .bold)
+      self.tagLabel.sizeToFit()
+
+    case false:
+      self.tagLabel.backgroundColor = .white
+      self.tagLabel.textColor = .green50
+      self.tagLabel.font = .systemFont(ofSize: 14, weight: .medium)
+      self.tagLabel.sizeToFit()
+    }
   }
 
   // MARK: - Configure

--- a/KnockKnock-iOS/Scenes/Feed/FeedInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedInteractor.swift
@@ -30,6 +30,9 @@ final class FeedInteractor: FeedInteractorProtocol {
 
   func getChallengeTitles() {
     self.worker?.getChallengeTitles { [weak self] challengeTitle in
+      var challengeTitle = challengeTitle
+      challengeTitle[0].isSelected = true
+
       self?.presenter?.presentGetChallengeTitles(challengeTitle: challengeTitle)
     }
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedInteractor.swift
@@ -34,7 +34,7 @@ final class FeedInteractor: FeedInteractorProtocol {
       var challengeTitle = challengeTitle
       challengeTitle[0].isSelected = true
 
-      self?.presenter?.presentGetChallengeTitles(challengeTitle: challengeTitle)
+      self?.presenter?.presentGetChallengeTitles(challengeTitle: challengeTitle, index: nil)
     }
   }
 
@@ -48,6 +48,6 @@ final class FeedInteractor: FeedInteractorProtocol {
         challengeTitles[index].isSelected = false
       }
     }
-    presenter?.presentGetChallengeTitles(challengeTitle: challengeTitles)
+    presenter?.presentGetChallengeTitles(challengeTitle: challengeTitles, index: selectedIndex)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedInteractor.swift
@@ -13,6 +13,7 @@ protocol FeedInteractorProtocol {
 
   func fetchFeed()
   func getChallengeTitles()
+  func setSelectedStatus(challengeTitles: [ChallengeTitle], selectedIndex: IndexPath)
 }
 
 final class FeedInteractor: FeedInteractorProtocol {
@@ -35,5 +36,18 @@ final class FeedInteractor: FeedInteractorProtocol {
 
       self?.presenter?.presentGetChallengeTitles(challengeTitle: challengeTitle)
     }
+  }
+
+  func setSelectedStatus(challengeTitles: [ChallengeTitle], selectedIndex: IndexPath) {
+    var challengeTitles = challengeTitles
+
+    for index in 0..<challengeTitles.count {
+      if index == selectedIndex.item {
+        challengeTitles[index].isSelected = true
+      } else {
+        challengeTitles[index].isSelected = false
+      }
+    }
+    presenter?.presentGetChallengeTitles(challengeTitle: challengeTitles)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedPresenter.swift
@@ -11,7 +11,7 @@ protocol FeedPresenterProtocol {
   var view: FeedViewProtocol? { get set }
   
   func presentFetchFeed(feed: [Feed])
-  func presentGetChallengeTitles(challengeTitle: [ChallengeTitle])
+  func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?)
 }
 
 final class FeedPresenter: FeedPresenterProtocol {
@@ -24,7 +24,7 @@ final class FeedPresenter: FeedPresenterProtocol {
     self.view?.fetchFeed(feed: feed)
   }
 
-  func presentGetChallengeTitles(challengeTitle: [ChallengeTitle]) {
-    self.view?.getChallengeTitles(challengeTitle: challengeTitle)
+  func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?) {
+    self.view?.getChallengeTitles(challengeTitle: challengeTitle, index: index)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedRouter.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol FeedRouterProtocol {
   static func createFeed() -> UIViewController
-  func navigateToFeedList(source: FeedViewController, destination: FeedListViewController)
+  func navigateToFeedList(source: FeedViewProtocol)
 }
 
 final class FeedRouter {
@@ -19,8 +19,10 @@ final class FeedRouter {
     let interactor = FeedInteractor()
     let presenter = FeedPresenter()
     let worker = FeedWorker(repository: FeedRepository())
+    let router = FeedRouter()
 
     view.interactor = interactor
+    view.router = router
     interactor.presenter = presenter
     interactor.worker = worker
     presenter.view = view
@@ -30,7 +32,10 @@ final class FeedRouter {
 }
 
 extension FeedRouter: FeedRouterProtocol {
-  func navigateToFeedList(source: FeedViewController, destination: FeedListViewController) {
-    source.show(destination, sender: nil)
+  func navigateToFeedList(source: FeedViewProtocol) {
+    let feedListViewController = FeedListRouter.createFeedList()
+    if let sourceView = source as? UIViewController {
+      sourceView.navigationController?.pushViewController(feedListViewController, animated: true)
+    }
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
@@ -18,11 +18,11 @@ final class FeedViewController: BaseViewController<FeedView> {
 
   // MARK: - Enums
 
-  private enum FeedSection: Int {
+  private enum CollectionViewTag: Int {
     case tag = 0
     case feed = 1
 
-    static let allCases: [FeedSection] = [.tag, .feed]
+    static let allCases: [CollectionViewTag] = [.tag, .feed]
   }
 
   // MARK: - Properties
@@ -37,19 +37,32 @@ final class FeedViewController: BaseViewController<FeedView> {
 
   override func viewDidLoad() {
     super.viewDidLoad()
+    self.extendedLayoutIncludesOpaqueBars = true
     self.interactor?.fetchFeed()
     self.interactor?.getChallengeTitles()
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
   }
 
   override func setupConfigure() {
     self.navigationItem.searchController = containerView.searchBar
 
-    self.containerView.feedCollectionView.do {
+    self.containerView.tagCollectionView.do {
       $0.delegate = self
       $0.dataSource = self
       $0.registCell(type: TagCell.self)
+      $0.collectionViewLayout = self.containerView.tagCollectionViewLayout()
+      $0.tag = CollectionViewTag.tag.rawValue
+    }
+
+    self.containerView.feedCollectionView.do {
+      $0.delegate = self
+      $0.dataSource = self
       $0.registCell(type: FeedCell.self)
       $0.collectionViewLayout = self.containerView.feedCollectionViewLayout()
+      $0.tag = CollectionViewTag.feed.rawValue
     }
   }
 }
@@ -67,14 +80,14 @@ extension FeedViewController: FeedViewProtocol {
 
     if let index = index {
       UIView.performWithoutAnimation {
-        self.containerView.feedCollectionView.reloadSections([FeedSection.tag.rawValue])
-        self.containerView.feedCollectionView.scrollToItem(
+        self.containerView.tagCollectionView.reloadSections([0])
+        self.containerView.tagCollectionView.scrollToItem(
           at: index,
           at: .centeredHorizontally,
           animated: false)
       }
     } else {
-      self.containerView.feedCollectionView.reloadData()
+      self.containerView.tagCollectionView.reloadData()
     }
   }
 }
@@ -84,11 +97,11 @@ extension FeedViewController: UICollectionViewDataSource {
     _ collectionView: UICollectionView,
     numberOfItemsInSection section: Int
   ) -> Int {
-    switch section {
-    case FeedSection.tag.rawValue:
+    switch collectionView.tag {
+    case CollectionViewTag.tag.rawValue:
       return self.challengeTitles.count
 
-    case FeedSection.feed.rawValue:
+    case CollectionViewTag.feed.rawValue:
       return self.feed.count
       
     default:
@@ -96,16 +109,12 @@ extension FeedViewController: UICollectionViewDataSource {
     }
   }
 
-  func numberOfSections(in collectionView: UICollectionView) -> Int {
-    return FeedSection.allCases.count
-  }
-
   func collectionView(
     _ collectionView: UICollectionView,
     cellForItemAt indexPath: IndexPath
   ) -> UICollectionViewCell {
-    switch indexPath.section {
-    case FeedSection.tag.rawValue:
+    switch collectionView.tag {
+    case CollectionViewTag.tag.rawValue:
       let cell = collectionView.dequeueCell(withType: TagCell.self, for: indexPath)
       cell.bind(tag: self.challengeTitles[indexPath.item])
 
@@ -116,7 +125,7 @@ extension FeedViewController: UICollectionViewDataSource {
 
       return cell
 
-    case FeedSection.feed.rawValue:
+    case CollectionViewTag.feed.rawValue:
       let cell = collectionView.dequeueCell(withType: FeedCell.self, for: indexPath)
       let feed = self.feed[indexPath.item]
       cell.bind(feed: feed)
@@ -142,14 +151,14 @@ extension FeedViewController: UICollectionViewDelegate {
     _ collectionView: UICollectionView,
     didSelectItemAt indexPath: IndexPath
   ) {
-    switch indexPath.section {
-    case FeedSection.tag.rawValue:
+    switch collectionView.tag {
+    case CollectionViewTag.tag.rawValue:
       self.interactor?.setSelectedStatus(
         challengeTitles: challengeTitles,
         selectedIndex: indexPath
       )
 
-    case FeedSection.feed.rawValue:
+    case CollectionViewTag.feed.rawValue:
       self.router.navigateToFeedList(
         source: self,
         destination: FeedListRouter.createFeedList() as! FeedListViewController

--- a/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
@@ -16,6 +16,15 @@ protocol FeedViewProtocol: AnyObject {
 
 final class FeedViewController: BaseViewController<FeedView> {
 
+  // MARK: - Enums
+
+  private enum FeedSection: Int {
+    case tag = 0
+    case feed = 1
+
+    static let allCases: [FeedSection] = [.tag, .feed]
+  }
+
   // MARK: - Properties
 
   var interactor: FeedInteractorProtocol?
@@ -23,7 +32,6 @@ final class FeedViewController: BaseViewController<FeedView> {
 
   var feed: [Feed] = []
   var challengeTitles: [ChallengeTitle] = []
-  var cellWidths: NSMutableDictionary = [:]
 
   // MARK: - Lify Cycles
 
@@ -59,7 +67,7 @@ extension FeedViewController: FeedViewProtocol {
 
     if let index = index {
       UIView.performWithoutAnimation {
-        self.containerView.feedCollectionView.reloadSections([0])
+        self.containerView.feedCollectionView.reloadSections([FeedSection.tag.rawValue])
         self.containerView.feedCollectionView.scrollToItem(
           at: index,
           at: .centeredHorizontally,
@@ -77,10 +85,10 @@ extension FeedViewController: UICollectionViewDataSource {
     numberOfItemsInSection section: Int
   ) -> Int {
     switch section {
-    case 0:
+    case FeedSection.tag.rawValue:
       return self.challengeTitles.count
 
-    case 1:
+    case FeedSection.feed.rawValue:
       return self.feed.count
       
     default:
@@ -89,7 +97,7 @@ extension FeedViewController: UICollectionViewDataSource {
   }
 
   func numberOfSections(in collectionView: UICollectionView) -> Int {
-    return 2
+    return FeedSection.allCases.count
   }
 
   func collectionView(
@@ -97,7 +105,7 @@ extension FeedViewController: UICollectionViewDataSource {
     cellForItemAt indexPath: IndexPath
   ) -> UICollectionViewCell {
     switch indexPath.section {
-    case 0:
+    case FeedSection.tag.rawValue:
       let cell = collectionView.dequeueCell(withType: TagCell.self, for: indexPath)
       cell.bind(tag: self.challengeTitles[indexPath.item])
 
@@ -108,7 +116,7 @@ extension FeedViewController: UICollectionViewDataSource {
 
       return cell
 
-    case 1:
+    case FeedSection.feed.rawValue:
       let cell = collectionView.dequeueCell(withType: FeedCell.self, for: indexPath)
       let feed = self.feed[indexPath.item]
       cell.bind(feed: feed)
@@ -135,13 +143,13 @@ extension FeedViewController: UICollectionViewDelegate {
     didSelectItemAt indexPath: IndexPath
   ) {
     switch indexPath.section {
-    case 0:
+    case FeedSection.tag.rawValue:
       self.interactor?.setSelectedStatus(
         challengeTitles: challengeTitles,
         selectedIndex: indexPath
       )
 
-    case 1:
+    case FeedSection.feed.rawValue:
       self.router.navigateToFeedList(
         source: self,
         destination: FeedListRouter.createFeedList() as! FeedListViewController

--- a/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
@@ -87,7 +87,7 @@ extension FeedViewController: UICollectionViewDataSource {
     switch indexPath.section {
     case 0:
       let cell = collectionView.dequeueCell(withType: TagCell.self, for: indexPath)
-      cell.bind(tag: self.challengeTitles[indexPath.item].title)
+      cell.bind(tag: self.challengeTitles[indexPath.item])
 
       if indexPath.item == 0 {
         cell.isSelected = true
@@ -122,9 +122,14 @@ extension FeedViewController: UICollectionViewDelegate {
     switch indexPath.section {
     case 0:
       if let cell = collectionView.cellForItem(at: indexPath) as? TagCell {
-        cell.tagLabel.backgroundColor = .green50
-        cell.tagLabel.textColor = .white
-        cell.tagLabel.font = .systemFont(ofSize: 16, weight: .bold)
+        for index in 0..<self.challengeTitles.count {
+          if index == indexPath.item {
+            self.challengeTitles[index].isSelected = true
+          } else {
+            self.challengeTitles[index].isSelected = false
+          }
+          cell.setLabel(isSelected: challengeTitles[indexPath.item].isSelected)
+        }
       }
 
     case 1:
@@ -136,11 +141,14 @@ extension FeedViewController: UICollectionViewDelegate {
   }
   
   func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-    if indexPath.section == 0 {
-      if let cell = collectionView.cellForItem(at: indexPath) as? TagCell {
-        cell.tagLabel.backgroundColor = .white
-        cell.tagLabel.textColor = .green50
-        cell.tagLabel.font = .systemFont(ofSize: 16, weight: .medium)
+    if let cell = collectionView.cellForItem(at: indexPath) as? TagCell {
+      for index in 0..<self.challengeTitles.count {
+        if index == indexPath.item {
+          self.challengeTitles[index].isSelected = false
+        } else {
+          self.challengeTitles[index].isSelected = true
+        }
+        cell.setLabel(isSelected: challengeTitles[indexPath.item].isSelected)
       }
     }
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
@@ -11,7 +11,7 @@ protocol FeedViewProtocol: AnyObject {
   var interactor: FeedInteractorProtocol? { get set }
 
   func fetchFeed(feed: [Feed])
-  func getChallengeTitles(challengeTitle: [ChallengeTitle])
+  func getChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?)
 }
 
 final class FeedViewController: BaseViewController<FeedView> {
@@ -23,6 +23,7 @@ final class FeedViewController: BaseViewController<FeedView> {
 
   var feed: [Feed] = []
   var challengeTitles: [ChallengeTitle] = []
+  var cellWidths: NSMutableDictionary = [:]
 
   // MARK: - Lify Cycles
 
@@ -53,9 +54,20 @@ extension FeedViewController: FeedViewProtocol {
     self.containerView.feedCollectionView.reloadData()
   }
 
-  func getChallengeTitles(challengeTitle: [ChallengeTitle]) {
+  func getChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?) {
     self.challengeTitles = challengeTitle
-    self.containerView.feedCollectionView.reloadData()
+
+    if let index = index {
+      UIView.performWithoutAnimation {
+        self.containerView.feedCollectionView.reloadSections([0])
+        self.containerView.feedCollectionView.scrollToItem(
+          at: index,
+          at: .centeredHorizontally,
+          animated: false)
+      }
+    } else {
+      self.containerView.feedCollectionView.reloadData()
+    }
   }
 }
 
@@ -118,20 +130,35 @@ extension FeedViewController: UICollectionViewDataSource {
 }
 
 extension FeedViewController: UICollectionViewDelegate {
-  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
     switch indexPath.section {
     case 0:
-      interactor?.setSelectedStatus(challengeTitles: challengeTitles, selectedIndex: indexPath)
+      self.interactor?.setSelectedStatus(
+        challengeTitles: challengeTitles,
+        selectedIndex: indexPath
+      )
 
     case 1:
-      self.router.navigateToFeedList(source: self, destination: FeedListRouter.createFeedList() as! FeedListViewController)
+      self.router.navigateToFeedList(
+        source: self,
+        destination: FeedListRouter.createFeedList() as! FeedListViewController
+      )
 
     default:
       return
     }
   }
   
-  func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-    interactor?.setSelectedStatus(challengeTitles: challengeTitles, selectedIndex: indexPath)
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didDeselectItemAt indexPath: IndexPath
+  ) {
+    self.interactor?.setSelectedStatus(
+      challengeTitles: challengeTitles,
+      selectedIndex: indexPath
+    )
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
@@ -121,16 +121,7 @@ extension FeedViewController: UICollectionViewDelegate {
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     switch indexPath.section {
     case 0:
-      if let cell = collectionView.cellForItem(at: indexPath) as? TagCell {
-        for index in 0..<self.challengeTitles.count {
-          if index == indexPath.item {
-            self.challengeTitles[index].isSelected = true
-          } else {
-            self.challengeTitles[index].isSelected = false
-          }
-          cell.setLabel(isSelected: challengeTitles[indexPath.item].isSelected)
-        }
-      }
+      interactor?.setSelectedStatus(challengeTitles: challengeTitles, selectedIndex: indexPath)
 
     case 1:
       self.router.navigateToFeedList(source: self, destination: FeedListRouter.createFeedList() as! FeedListViewController)
@@ -141,15 +132,6 @@ extension FeedViewController: UICollectionViewDelegate {
   }
   
   func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-    if let cell = collectionView.cellForItem(at: indexPath) as? TagCell {
-      for index in 0..<self.challengeTitles.count {
-        if index == indexPath.item {
-          self.challengeTitles[index].isSelected = false
-        } else {
-          self.challengeTitles[index].isSelected = true
-        }
-        cell.setLabel(isSelected: challengeTitles[indexPath.item].isSelected)
-      }
-    }
+    interactor?.setSelectedStatus(challengeTitles: challengeTitles, selectedIndex: indexPath)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedViewController.swift
@@ -28,7 +28,7 @@ final class FeedViewController: BaseViewController<FeedView> {
   // MARK: - Properties
 
   var interactor: FeedInteractorProtocol?
-  var router = FeedRouter()
+  var router: FeedRouterProtocol?
 
   var feed: [Feed] = []
   var challengeTitles: [ChallengeTitle] = []
@@ -159,10 +159,7 @@ extension FeedViewController: UICollectionViewDelegate {
       )
 
     case CollectionViewTag.feed.rawValue:
-      self.router.navigateToFeedList(
-        source: self,
-        destination: FeedListRouter.createFeedList() as! FeedListViewController
-      )
+      self.router?.navigateToFeedList(source: self)
 
     default:
       return

--- a/KnockKnock-iOS/Scenes/Feed/Views/FeedView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Views/FeedView.swift
@@ -14,8 +14,13 @@ class FeedView: UIView {
   // MARK: - Constants
   
   private enum Metric {
+    static let tagCollectionViewItemSpacing = 5.f
+    static let tagCollectionViewLeadingMargin = 20.f
+    static let tagCollectionViewTrailingMargin = -20.f
+    static let tagCollectionViewHeight = 50.f
+
     static let gradientImageViewWidth = 30.f
-    static let gradientImageViewHeight = 60.f
+    static let gradientImageViewHeight = 40.f
     
     static let feedCollectionViewLeadingMargin = 15.f
     static let feedCollectionViewTrailingMargin = -15.f
@@ -30,13 +35,25 @@ class FeedView: UIView {
   
   // MARK: - UIs
   
-  let searchBar = UISearchController()
- 
+  let searchBar = UISearchController().then {
+    $0.hidesNavigationBarDuringPresentation = false
+  }
+
   let gradientImageView = UIImageView().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
     $0.image = UIImage(named: "tagButton_gradient")
   }
-  
+
+  let tagCollectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: UICollectionViewFlowLayout().then {
+      $0.scrollDirection = .horizontal
+    }
+  ).then {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.alwaysBounceVertical = false
+  }
+
   let feedCollectionView = UICollectionView(
     frame: .zero,
     collectionViewLayout: UICollectionViewFlowLayout().then {
@@ -63,53 +80,62 @@ class FeedView: UIView {
   // MARK: - Constraints
   
   func setupConstraints() {
-    [self.feedCollectionView].addSubViews(self)
+    [self.tagCollectionView, self.feedCollectionView].addSubViews(self)
     [self.gradientImageView].addSubViews(self)
     
     NSLayoutConstraint.activate([
+      self.tagCollectionView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
+      self.tagCollectionView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: Metric.tagCollectionViewLeadingMargin),
+      self.tagCollectionView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: Metric.tagCollectionViewTrailingMargin),
+      self.tagCollectionView.heightAnchor.constraint(equalToConstant: Metric.tagCollectionViewHeight),
+
       self.gradientImageView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
-      self.gradientImageView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor),
-      self.gradientImageView.heightAnchor.constraint(equalToConstant: Metric.gradientImageViewHeight),
-      self.gradientImageView.widthAnchor.constraint(equalToConstant: Metric.gradientImageViewWidth),
+      self.gradientImageView.trailingAnchor.constraint(equalTo: self.tagCollectionView.trailingAnchor),
+      self.gradientImageView.bottomAnchor.constraint(equalTo: self.tagCollectionView.bottomAnchor),
       
-      self.feedCollectionView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
+      self.feedCollectionView.topAnchor.constraint(equalTo: self.tagCollectionView.bottomAnchor),
       self.feedCollectionView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: Metric.feedCollectionViewLeadingMargin),
       self.feedCollectionView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: Metric.feedCollectionViewTrailingMargin),
       self.feedCollectionView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor)
     ])
   }
-  
-  func feedCollectionViewLayout() -> UICollectionViewCompositionalLayout {
-    let sectionTwoInset: CGFloat = 2.5
 
-    // section 1
+  func tagCollectionViewLayout() -> UICollectionViewCompositionalLayout {
     let estimatedWidth: CGFloat = 50
     let estimatedHeigth: CGFloat = 60
 
     let tagItemSize = NSCollectionLayoutSize(widthDimension: .estimated(estimatedWidth),
-                                            heightDimension: .estimated(estimatedHeigth))
+                                             heightDimension: .estimated(estimatedHeigth))
     let tagItem = NSCollectionLayoutItem(layoutSize: tagItemSize)
 
     let tagGroupSize = NSCollectionLayoutSize(widthDimension: .estimated(estimatedWidth), heightDimension: .estimated(estimatedHeigth))
     let tagGroup = NSCollectionLayoutGroup.vertical(layoutSize: tagGroupSize, subitems: [tagItem])
 
-    let sectionOne = NSCollectionLayoutSection(group: tagGroup)
-    sectionOne.interGroupSpacing = 10
-    sectionOne.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0.0, bottom: 15, trailing: 0.0)
-    sectionOne.orthogonalScrollingBehavior = .continuous
+    let section = NSCollectionLayoutSection(group: tagGroup)
+    section.interGroupSpacing = 10
+    section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0.0, bottom: 0, trailing: 0.0)
+    section.orthogonalScrollingBehavior = .continuous
+
+    let layout = UICollectionViewCompositionalLayout(section: section)
+
+    return layout
+  }
+
+  func feedCollectionViewLayout() -> UICollectionViewCompositionalLayout {
+    let sectionInset: CGFloat = 2.5
 
     // section 2
     let largeItemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.666), heightDimension: .fractionalHeight(1))
     let largeItem = NSCollectionLayoutItem(layoutSize: largeItemSize)
-    largeItem.contentInsets = NSDirectionalEdgeInsets(top: sectionTwoInset, leading: sectionTwoInset, bottom: sectionTwoInset, trailing: sectionTwoInset)
+    largeItem.contentInsets = NSDirectionalEdgeInsets(top: sectionInset, leading: sectionInset, bottom: sectionInset, trailing: sectionInset)
     
     let verticalSmallItemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(0.5))
     let verticalSmallItem = NSCollectionLayoutItem(layoutSize: verticalSmallItemSize)
-    verticalSmallItem.contentInsets = NSDirectionalEdgeInsets(top: sectionTwoInset, leading: sectionTwoInset, bottom: sectionTwoInset, trailing: sectionTwoInset)
+    verticalSmallItem.contentInsets = NSDirectionalEdgeInsets(top: sectionInset, leading: sectionInset, bottom: sectionInset, trailing: sectionInset)
     
     let horizontalSmallItemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.333), heightDimension: .fractionalHeight(1))
     let horizontalSmallItem = NSCollectionLayoutItem(layoutSize: horizontalSmallItemSize)
-    horizontalSmallItem.contentInsets = NSDirectionalEdgeInsets(top: sectionTwoInset, leading: sectionTwoInset, bottom: sectionTwoInset, trailing: sectionTwoInset)
+    horizontalSmallItem.contentInsets = NSDirectionalEdgeInsets(top: sectionInset, leading: sectionInset, bottom: sectionInset, trailing: sectionInset)
     
     let verticalGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.333), heightDimension: .fractionalHeight(1))
     let verticalGroup = NSCollectionLayoutGroup.vertical(layoutSize: verticalGroupSize, subitems: [verticalSmallItem])
@@ -129,23 +155,16 @@ class FeedView: UIView {
     let outerGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalWidth(2.666))
     let outerGroup = NSCollectionLayoutGroup.vertical(layoutSize: outerGroupSize, subitems: [largeFirstMixedGroup, twoHorizontalGroup, verticalFirstMixedGroup, twoHorizontalGroup])
     
-    let sectionTwo = NSCollectionLayoutSection(group: outerGroup)
+    let section = NSCollectionLayoutSection(group: outerGroup)
 
     // footer
     let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(50.0))
     let footer = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: footerSize, elementKind: UICollectionView.elementKindSectionFooter, alignment: .bottom)
     footer.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
 
-    sectionTwo.boundarySupplementaryItems = [footer]
+    section.boundarySupplementaryItems = [footer]
 
-    let layout = UICollectionViewCompositionalLayout { (section: Int, _) -> NSCollectionLayoutSection? in
-      if section == 0 {
-        return sectionOne
-
-      } else {
-        return sectionTwo
-      }
-    }
+    let layout = UICollectionViewCompositionalLayout(section: section)
     
     return layout
   }

--- a/KnockKnock-iOS/Scenes/Feed/Views/FeedView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Views/FeedView.swift
@@ -17,8 +17,8 @@ class FeedView: UIView {
     static let gradientImageViewWidth = 30.f
     static let gradientImageViewHeight = 60.f
     
-    static let scrollViewLeadingMargin = 15.f
-    static let scrollViewTrailingMargin = -15.f
+    static let feedCollectionViewLeadingMargin = 15.f
+    static let feedCollectionViewTrailingMargin = -15.f
     
     static let feedCollectionViewLineSpacing = 10.f
     static let feedCollectionViewItemSpacing = 10.f
@@ -73,8 +73,8 @@ class FeedView: UIView {
       self.gradientImageView.widthAnchor.constraint(equalToConstant: Metric.gradientImageViewWidth),
       
       self.feedCollectionView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
-      self.feedCollectionView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: Metric.scrollViewLeadingMargin),
-      self.feedCollectionView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: Metric.scrollViewTrailingMargin),
+      self.feedCollectionView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: Metric.feedCollectionViewLeadingMargin),
+      self.feedCollectionView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: Metric.feedCollectionViewTrailingMargin),
       self.feedCollectionView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor)
     ])
   }


### PR DESCRIPTION
## What is this PR?
- 피드 검색에 사용 될 tag의 선택/비선택 상태 변화 이벤트 로직을 수정하였습니다.

## Changes
- `ChallengeTitle` entity에 `isSelected` property를 추가하여 선택 상태를 관리합니다.
- 초기 화면은 '전체'가 선택 된 상태로 나타납니다.
- 다른 tag 선택시 기존에 선택 한 tag는 선택이 해제 됩니다.

## Test Checklist
- 현재 사용 중인 'Tag' 명칭에 대한 논의가 필요해보입니다.