### PR TITLE
[FIX] Bottom modal 이상 동작 이슈 해결

### DIFF
--- a/KnockKnock-iOS.xcodeproj/project.pbxproj
+++ b/KnockKnock-iOS.xcodeproj/project.pbxproj
@@ -76,8 +76,9 @@
 		618FDAC727E82A6F00C2823F /* AddressCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618FDAC627E82A6F00C2823F /* AddressCell.swift */; };
 		618FDAC927E836BA00C2823F /* PhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618FDAC827E836BA00C2823F /* PhotoCell.swift */; };
 		618FDACF27E9642400C2823F /* UIButton+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618FDACE27E9642400C2823F /* UIButton+Ext.swift */; };
-		61E3088428768D71001394B6 /* UIStackView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E3088328768D71001394B6 /* UIStackView+Ext.swift */; };
+		61A8DC44287E8783000512EC /* UIDevice+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A8DC43287E8783000512EC /* UIDevice+Ext.swift */; };
 		61E3087C287334C1001394B6 /* ImageScaleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E3087B287334C1001394B6 /* ImageScaleType.swift */; };
+		61E3088428768D71001394B6 /* UIStackView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E3088328768D71001394B6 /* UIStackView+Ext.swift */; };
 		61FC60E927B9244D00A51DBC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60E827B9244D00A51DBC /* AppDelegate.swift */; };
 		61FC60EB27B9244E00A51DBC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60EA27B9244E00A51DBC /* SceneDelegate.swift */; };
 		61FC60ED27B9244E00A51DBC /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60EC27B9244E00A51DBC /* MainTabBarController.swift */; };
@@ -155,8 +156,9 @@
 		618FDAC627E82A6F00C2823F /* AddressCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressCell.swift; sourceTree = "<group>"; };
 		618FDAC827E836BA00C2823F /* PhotoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCell.swift; sourceTree = "<group>"; };
 		618FDACE27E9642400C2823F /* UIButton+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Ext.swift"; sourceTree = "<group>"; };
-		61E3088328768D71001394B6 /* UIStackView+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Ext.swift"; sourceTree = "<group>"; };
+		61A8DC43287E8783000512EC /* UIDevice+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Ext.swift"; sourceTree = "<group>"; };
 		61E3087B287334C1001394B6 /* ImageScaleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageScaleType.swift; sourceTree = "<group>"; };
+		61E3088328768D71001394B6 /* UIStackView+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Ext.swift"; sourceTree = "<group>"; };
 		61FC60E527B9244D00A51DBC /* KnockKnock-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "KnockKnock-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61FC60E827B9244D00A51DBC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61FC60EA27B9244E00A51DBC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -220,10 +222,9 @@
 				618FDACE27E9642400C2823F /* UIButton+Ext.swift */,
 				61215ACF28559B6E003FDCAA /* UICollectionViewCell+Ext.swift */,
 				61215AD228559BD0003FDCAA /* UICollectionView+Ext.swift */,
-				61215AE72858B2D3003FDCAA /* UIScrollView+Ext.swift */,
-				61215AEB285ADFF8003FDCAA /* UICollectionLayoutSize+Ext.swift */,
 				61E3088328768D71001394B6 /* UIStackView+Ext.swift */,
 				6143296528642745008BDCC9 /* UILabel+Ext.swift */,
+				61A8DC43287E8783000512EC /* UIDevice+Ext.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -636,6 +637,7 @@
 				20D28F8027CFC5E800A809DB /* ChallengeInteractor.swift in Sources */,
 				20A72D1E280BC4EE006689FC /* BaseCollectionViewCell.swift in Sources */,
 				6143297828687B69008BDCC9 /* FeedListInteractor.swift in Sources */,
+				61A8DC44287E8783000512EC /* UIDevice+Ext.swift in Sources */,
 				20D28F8227CFC5F000A809DB /* ChallengePresenter.swift in Sources */,
 				61215ACB2852D5B5003FDCAA /* APIConstants.swift in Sources */,
 				61215AC928507D51003FDCAA /* KKRouter.swift in Sources */,

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIDevice+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIDevice+Ext.swift
@@ -19,14 +19,10 @@ extension UIDevice {
 
     guard let rootView = rootView else { return 0 }
 
-    if #available(iOS 11.0, *) {
-      let topInset = rootView.safeAreaInsets.top
-      let bottomInset = rootView.safeAreaInsets.bottom
+    let topInset = rootView.safeAreaInsets.top
+    let bottomInset = rootView.safeAreaInsets.bottom
 
-      return rootView.bounds.height - topInset - bottomInset
+    return rootView.bounds.height - topInset - bottomInset
 
-    } else {
-      return rootView.bounds.height
-    }
   }
 }

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIDevice+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIDevice+Ext.swift
@@ -1,0 +1,27 @@
+//
+//  UIDevice+Ext.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2022/07/13.
+//
+
+import UIKit
+
+extension UIDevice {
+
+  /// 노치가 있는 디바이스에서 top, bottom safeAreaInset을 제외한 스크린의 전체 높이를 반환해주는 메소드
+  func heightOfSafeArea() -> CGFloat {
+    guard let rootView = UIApplication.shared.keyWindow else { return 0 }
+
+    if #available(iOS 11.0, *) {
+      let topInset = rootView.safeAreaInsets.top
+      let bottomInset = rootView.safeAreaInsets.bottom
+
+      return rootView.bounds.height - topInset - bottomInset
+
+    } else {
+      return rootView.bounds.height
+    }
+  }
+}
+

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIDevice+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIDevice+Ext.swift
@@ -11,7 +11,13 @@ extension UIDevice {
 
   /// 노치가 있는 디바이스에서 top, bottom safeAreaInset을 제외한 스크린의 전체 높이를 반환해주는 메소드
   func heightOfSafeArea() -> CGFloat {
-    guard let rootView = UIApplication.shared.keyWindow else { return 0 }
+    let rootView = UIApplication
+      .shared
+      .connectedScenes
+      .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+      .first { $0.isKeyWindow }
+
+    guard let rootView = rootView else { return 0 }
 
     if #available(iOS 11.0, *) {
       let topInset = rootView.safeAreaInsets.top
@@ -24,4 +30,3 @@ extension UIDevice {
     }
   }
 }
-

--- a/KnockKnock-iOS/Scenes/BottomSheetView.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheetView.swift
@@ -25,9 +25,14 @@ final class BottomSheetView: UIView {
   }
 
   // MARK: - Properties
+  let screenHeight = UIDevice.current.heightOfSafeArea()
+  lazy var topConstant = self.safeAreaInsets.bottom + self.screenHeight
+  lazy var bottomSheetViewTopConstraint: NSLayoutConstraint = self.bottomSheetView.topAnchor.constraint(
+    equalTo: self.safeAreaLayoutGuide.topAnchor,
+    constant: topConstant
+  )
 
-  lazy var topConstant = self.safeAreaInsets.bottom + self.safeAreaLayoutGuide.layoutFrame.height
-  lazy var bottomSheetViewTopConstraint: NSLayoutConstraint = self.bottomSheetView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: topConstant)
+  let bottomHeight: CGFloat = 150
 
   // MARK: - UIs
 
@@ -69,6 +74,37 @@ final class BottomSheetView: UIView {
     super.init(coder: aDecoder)
   }
 
+  // MARK: - Bottom Sheet Animation
+
+  func showBottomSheet() {
+    let safeAreaHeight: CGFloat = self.safeAreaLayoutGuide.layoutFrame.height
+    let bottomPadding: CGFloat = self.safeAreaInsets.bottom
+
+    self.bottomSheetViewTopConstraint.constant = (safeAreaHeight + bottomPadding) - self.bottomHeight
+
+    UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseIn, animations: {
+      self.dimmedBackView.alpha = 0.5
+      self.layoutIfNeeded()
+    }, completion: nil)
+  }
+
+  func hideBottomSheet(view: BottomSheetViewController) {
+    let safeAreaHeight = self.safeAreaLayoutGuide.layoutFrame.height
+    let bottomPadding = self.safeAreaInsets.bottom
+
+    self.bottomSheetViewTopConstraint.constant = safeAreaHeight + bottomPadding
+    UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseIn, animations: {
+      self.dimmedBackView.alpha = 0.0
+      self.layoutIfNeeded()
+    }) { _ in
+      if view.presentingViewController != nil {
+        view.dismiss(animated: false, completion: nil)
+      }
+    }
+  }
+
+  // MARK: - Constraints
+
   private func setupConstraints() {
     [self.dimmedBackView, self.bottomSheetView].addSubViews(self)
     [self.dismissIndicatorView, self.tableView].addSubViews(self.bottomSheetView)
@@ -82,7 +118,7 @@ final class BottomSheetView: UIView {
       self.bottomSheetView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
       self.bottomSheetView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor),
       self.bottomSheetView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-      self.bottomSheetViewTopConstraint,
+      bottomSheetViewTopConstraint,
 
       self.dismissIndicatorView.widthAnchor.constraint(equalToConstant: Metric.dismissIndicatorViewWidth),
       self.dismissIndicatorView.heightAnchor.constraint(equalToConstant: Metric.dismissIndicatorViewHeight),

--- a/KnockKnock-iOS/Scenes/BottomSheetViewController.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheetViewController.swift
@@ -13,7 +13,6 @@ class BottomSheetViewController: BaseViewController<BottomSheetView> {
 
   // MARK: - Properties
 
-  let bottomHeight: CGFloat = 150
   private var tableContents: [String] = []
 
   // MARK: - Life Cycle
@@ -26,23 +25,26 @@ class BottomSheetViewController: BaseViewController<BottomSheetView> {
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-    self.showBottomSheet()
+    self.containerView.showBottomSheet()
   }
   
-  // MARK: - Functions
+  // MARK: - Configure
 
   override func setupConfigure() {
     self.view.backgroundColor = .clear
     self.containerView.tableView.do {
-      $0.delegate = self
       $0.dataSource = self
     }
     self.containerView.dimmedBackView.alpha = 0.0
   }
 
+  // MARK: - Bind
+
   func setBottomSheetContents(contents: [String]) {
     self.tableContents = contents
   }
+
+  // MARK: - Gesture
 
   private func setupGestureRecognizer() {
     let dimmedTap = UITapGestureRecognizer(target: self, action: #selector(dimmedViewTapped(_:)))
@@ -54,48 +56,23 @@ class BottomSheetViewController: BaseViewController<BottomSheetView> {
     self.view.addGestureRecognizer(swipeGesture)
   }
 
-  private func showBottomSheet() {
-    let safeAreaHeight: CGFloat = self.containerView.safeAreaLayoutGuide.layoutFrame.height
-    let bottomPadding: CGFloat = self.containerView.safeAreaInsets.bottom
-
-    self.containerView.bottomSheetViewTopConstraint.constant = (safeAreaHeight + bottomPadding) - self.bottomHeight
-
-    UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
-      self.containerView.dimmedBackView.alpha = 0.5
-      self.containerView.layoutIfNeeded()
-    }, completion: nil)
-  }
-
-  private func hideBottomSheet() {
-    let safeAreaHeight = self.containerView.safeAreaLayoutGuide.layoutFrame.height
-    let bottomPadding = self.containerView.safeAreaInsets.bottom
-
-    self.containerView.bottomSheetViewTopConstraint.constant = safeAreaHeight + bottomPadding
-    UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
-      self.containerView.dimmedBackView.alpha = 0.0
-      self.containerView.layoutIfNeeded()
-    }) { _ in
-      if self.presentingViewController != nil {
-        self.dismiss(animated: false, completion: nil)
-      }
-    }
-  }
-
   @objc private func dimmedViewTapped(_ tapRecognizer: UITapGestureRecognizer) {
-    self.hideBottomSheet()
+    self.containerView.hideBottomSheet(view: self)
   }
 
   @objc func panGesture(_ recognizer: UISwipeGestureRecognizer) {
     if recognizer.state == .ended {
       switch recognizer.direction {
       case .down:
-        self.hideBottomSheet()
+        self.containerView.hideBottomSheet(view: self)
       default:
         break
       }
     }
   }
 }
+
+// MARK: - TableView DataSource
 
 extension BottomSheetViewController: UITableViewDataSource {
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -110,9 +87,6 @@ extension BottomSheetViewController: UITableViewDataSource {
 
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     print("\(indexPath.row) is selected.")
-    self.hideBottomSheet()
+    self.containerView.hideBottomSheet(view: self)
   }
-}
-
-extension BottomSheetViewController: UITableViewDelegate {
 }


### PR DESCRIPTION
## What is this PR?
- `BottomSheetView.topAnchor` 값을 결정하는 스크린의 전체 높이가 0으로 반환되면서 동작 시 위에서 아래로 떨어지는 현상을 해결하였습니다.

## Changes
- `UIDevice extension`에 `heightOfSafeArea()` 메소드를 추가하였습니다.
  - 현재 보여지고 있는 화면의 height에서 `safeAreaInset`(top, bottom)를 뺀 값을 반환합니다.

## Test Checklist
- none.