### PR TITLE
[FIX] 인증 된 스토어 혜택 부분 layout 수정

### DIFF
--- a/KnockKnock-iOS/Scenes/Cells/Home/StoreListCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/Home/StoreListCell.swift
@@ -68,26 +68,18 @@ final class StoreListCell: BaseCollectionViewCell {
   // MARK: - Configure
 
   private func setPromotionView(promotions: [String]) -> [UILabel] {
-    var labels: [UILabel] = []
-
-    for index in 0..<promotions.count {
-      let label = BasePaddingLabel(
-        padding: UIEdgeInsets(
-          top: 5,
-          left: 5,
-          bottom: 5,
-          right: 5
-        )).then {
-          $0.text = promotions[index]
-          $0.font = .systemFont(ofSize: 10)
-          $0.textColor = .gray70
-          $0.clipsToBounds = true
-          $0.layer.cornerRadius = 5
-          $0.backgroundColor = .gray20
-        }
-      labels.append(label)
+    return promotions.map { promotion in
+      BasePaddingLabel(
+        padding: .init(top: 5, left: 5, bottom: 5, right: 5)
+      ).then {
+        $0.text = promotion
+        $0.font = .systemFont(ofSize: 10)
+        $0.textColor = .gray70
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = 5
+        $0.backgroundColor = .gray20
+      }
     }
-    return labels
   }
 
   /// label들의 총 길이를 구해서 Cell의 contentView width를 넘으면 cut 처리
@@ -116,7 +108,7 @@ final class StoreListCell: BaseCollectionViewCell {
       if let nsStringText = NSString(utf8String: labels[index].text ?? "") {
         let labelWidth = nsStringText.size(
           withAttributes: [
-            NSAttributedString.Key.font : labels[index].font
+            NSAttributedString.Key.font: labels[index].font ?? .systemFont(ofSize: 12)
           ]
         ).width
         totalLength += labelWidth + 5

--- a/KnockKnock-iOS/Scenes/Cells/Home/StoreListCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/Home/StoreListCell.swift
@@ -90,6 +90,9 @@ final class StoreListCell: BaseCollectionViewCell {
     return labels
   }
 
+  /// label들의 총 길이를 구해서 Cell의 contentView width를 넘으면 cut 처리
+  /// labels width + 5 x n(marigns)  > contentView.width - 135(other ui's width, margins)이면,
+  /// 마지막 label의 trailing을 contentView.trailing으로 설정하고, 남은 라벨은 뷰에 추가하지 않음
   private func setPromotionStackView(promotions: [String]) {
 
     let labels = self.setPromotionView(promotions: promotions)

--- a/KnockKnock-iOS/Scenes/Cells/Home/StoreListCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/Home/StoreListCell.swift
@@ -31,7 +31,7 @@ final class StoreListCell: BaseCollectionViewCell {
 
   // MARK: - Properties
 
-  private let promotions = ["텀블러 할인", "사은품 증정", "포인트 적립", "텀블러 할인"]
+  private let promotions = ["텀블러 할인", "사은품 증정", "포인트 적립", "텀블러 할인", "포인트 적립", "텀블러 할인"]
 
   // MARK: - UIs
 
@@ -53,11 +53,7 @@ final class StoreListCell: BaseCollectionViewCell {
     $0.textColor = .gray70
   }
 
-  private let promotionStackView = UIStackView().then {
-    $0.axis = .horizontal
-    $0.spacing = 5
-    $0.alignment = .bottom
-  }
+  private let promotionsView = UIView()
 
   private let separatorLineView = UIView().then {
     $0.backgroundColor = .gray30
@@ -71,7 +67,9 @@ final class StoreListCell: BaseCollectionViewCell {
 
   // MARK: - Configure
 
-  private func setPromotionStackView(promotions: [String]) {
+  private func setPromotionView(promotions: [String]) -> [UILabel] {
+    var labels: [UILabel] = []
+
     for index in 0..<promotions.count {
       let label = BasePaddingLabel(
         padding: UIEdgeInsets(
@@ -87,13 +85,46 @@ final class StoreListCell: BaseCollectionViewCell {
           $0.layer.cornerRadius = 5
           $0.backgroundColor = .gray20
         }
-      if index == promotions.count - 1 {
-        label.setContentCompressionResistancePriority(
-          UILayoutPriority.defaultLow,
-          for: .horizontal
-        )
+      labels.append(label)
+    }
+    return labels
+  }
+
+  private func setPromotionStackView(promotions: [String]) {
+
+    let labels = self.setPromotionView(promotions: promotions)
+    var totalLength = -5.f
+
+    for index in 0..<labels.count {
+      self.promotionsView.addSubview(labels[index])
+
+      if index == 0 {
+        labels[index].snp.makeConstraints {
+          $0.leading.equalToSuperview()
+          $0.top.bottom.equalToSuperview()
+        }
+      } else {
+        labels[index].snp.makeConstraints {
+          $0.leading.equalTo(labels[index-1].snp.trailing).offset(5)
+          $0.top.bottom.equalToSuperview()
+        }
       }
-      self.promotionStackView.addArrangedSubview(label)
+
+      if let nsStringText = NSString(utf8String: labels[index].text ?? "") {
+        let labelWidth = nsStringText.size(
+          withAttributes: [
+            NSAttributedString.Key.font : labels[index].font
+          ]
+        ).width
+        totalLength += labelWidth + 5
+      }
+
+      if totalLength > (self.contentView.frame.width - 135) {
+        labels[index].snp.makeConstraints {
+          $0.trailing.equalToSuperview()
+        }
+        break
+      }
     }
   }
 
@@ -102,7 +133,7 @@ final class StoreListCell: BaseCollectionViewCell {
   }
 
   override func setupConstraints() {
-    [self.thumbnailImageView, self.storeNameLabel, self.storeInfoLabel, self.promotionStackView, self.separatorLineView].addSubViews(self.contentView)
+    [self.thumbnailImageView, self.storeNameLabel, self.storeInfoLabel, self.promotionsView, self.separatorLineView].addSubViews(self.contentView)
 
     self.thumbnailImageView.snp.makeConstraints {
       $0.bottom.equalTo(self.contentView).offset(Metric.thumbnailImageViewBottomMargin)
@@ -122,7 +153,7 @@ final class StoreListCell: BaseCollectionViewCell {
       $0.trailing.equalTo(self.contentView.snp.trailing)
     }
 
-    self.promotionStackView.snp.makeConstraints {
+    self.promotionsView.snp.makeConstraints {
       $0.leading.equalTo(self.thumbnailImageView.snp.trailing).offset(Metric.promotionStackViewLeadingMargin)
       $0.trailing.equalTo(self.contentView.snp.trailing)
       $0.top.equalTo(self.storeInfoLabel.snp.bottom).offset(Metric.promotionStackViewTopMargin)


### PR DESCRIPTION
## What is this PR?
- 인증 된 스토어 목록 화면에서 혜택 표기 부분의 label margin이 잘못 설정되는 부분을 수정하였습니다. 
- Before
![스크린샷 2022-09-05 15 01 14](https://user-images.githubusercontent.com/40792935/188370891-547c3ee4-534f-42ad-a60f-62de68b48a71.png)
- After
![스크린샷 2022-09-13 17 17 31](https://user-images.githubusercontent.com/40792935/189848964-2130cc66-f28e-4230-ba04-4f43554e71ed.png)

## Changes
- `UIStackView`를 이용하여 `UILabel`들을 자동 정렬하도록 했던 로직을 `UIView`에 `UILabel`을 추가하는 방식으로 변경하였습니다.
- `UILabel`이 추가 될 때마다 더한 총 길이와 다른 UI들의 wdith를 합한 값이 전체 view의 길이를 넘으면 라벨 생성을 멈추도록 하였습니다.  

## Test Checklist
- 화면에 따라 '...'가 들어갈 수 없는 짧은 길이의 경우 width으로 표시 되지 않는 이슈가 있습니다.
  - 일단은 수정 처리하였으나, 기획 단계에서 전반적인 ui 수정이 필요해보입니다. 