### PR TITLE
[FEAT] 피드 검색 기록 저장/불러오기

### DIFF
--- a/KnockKnock-iOS.xcodeproj/project.pbxproj
+++ b/KnockKnock-iOS.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		61E87EB928D1894A0005CAA6 /* FeedSearchPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EB828D1894A0005CAA6 /* FeedSearchPresenter.swift */; };
 		61E87EBB28D189570005CAA6 /* FeedSearchWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EBA28D189570005CAA6 /* FeedSearchWorker.swift */; };
 		61E87EBD28D189640005CAA6 /* FeedSearchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EBC28D189640005CAA6 /* FeedSearchRouter.swift */; };
+		61E87EBF28D1A1F20005CAA6 /* SearchLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EBE28D1A1F20005CAA6 /* SearchLog.swift */; };
 		61FC60E927B9244D00A51DBC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60E827B9244D00A51DBC /* AppDelegate.swift */; };
 		61FC60EB27B9244E00A51DBC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60EA27B9244E00A51DBC /* SceneDelegate.swift */; };
 		61FC60ED27B9244E00A51DBC /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60EC27B9244E00A51DBC /* MainTabBarController.swift */; };
@@ -312,6 +313,7 @@
 		61E87EB828D1894A0005CAA6 /* FeedSearchPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchPresenter.swift; sourceTree = "<group>"; };
 		61E87EBA28D189570005CAA6 /* FeedSearchWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchWorker.swift; sourceTree = "<group>"; };
 		61E87EBC28D189640005CAA6 /* FeedSearchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchRouter.swift; sourceTree = "<group>"; };
+		61E87EBE28D1A1F20005CAA6 /* SearchLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLog.swift; sourceTree = "<group>"; };
 		61FC60E527B9244D00A51DBC /* KnockKnock-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "KnockKnock-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61FC60E827B9244D00A51DBC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61FC60EA27B9244E00A51DBC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				6143296728644187008BDCC9 /* Feed.swift */,
 				619DEE9B28868E7E00C80095 /* Comment.swift */,
 				613856CC2898B64000BE347E /* Like.swift */,
+				61E87EBE28D1A1F20005CAA6 /* SearchLog.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -1073,6 +1076,7 @@
 				616EB08B28910485001BD18C /* PostHeaderReusableView.swift in Sources */,
 				618D8B5A28BDA12500828794 /* FeedSearchViewController.swift in Sources */,
 				6143297A28687B74008BDCC9 /* FeedListPresenter.swift in Sources */,
+				61E87EBF28D1A1F20005CAA6 /* SearchLog.swift in Sources */,
 				618FDAC927E836BA00C2823F /* PhotoCell.swift in Sources */,
 				61AB2E5428A3775300A1AE30 /* Double+Ext.swift in Sources */,
 				61B6D998288C40BF00E60F08 /* HomeSection.swift in Sources */,

--- a/KnockKnock-iOS.xcodeproj/project.pbxproj
+++ b/KnockKnock-iOS.xcodeproj/project.pbxproj
@@ -153,6 +153,10 @@
 		61C21D0628C4C971009B5F4E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 61C21D0528C4C971009B5F4E /* GoogleService-Info.plist */; };
 		61E3087C287334C1001394B6 /* ImageScaleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E3087B287334C1001394B6 /* ImageScaleType.swift */; };
 		61E3088428768D71001394B6 /* UIStackView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E3088328768D71001394B6 /* UIStackView+Ext.swift */; };
+		61E87EB728D189390005CAA6 /* FeedSearchInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EB628D189390005CAA6 /* FeedSearchInteractor.swift */; };
+		61E87EB928D1894A0005CAA6 /* FeedSearchPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EB828D1894A0005CAA6 /* FeedSearchPresenter.swift */; };
+		61E87EBB28D189570005CAA6 /* FeedSearchWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EBA28D189570005CAA6 /* FeedSearchWorker.swift */; };
+		61E87EBD28D189640005CAA6 /* FeedSearchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EBC28D189640005CAA6 /* FeedSearchRouter.swift */; };
 		61FC60E927B9244D00A51DBC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60E827B9244D00A51DBC /* AppDelegate.swift */; };
 		61FC60EB27B9244E00A51DBC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60EA27B9244E00A51DBC /* SceneDelegate.swift */; };
 		61FC60ED27B9244E00A51DBC /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60EC27B9244E00A51DBC /* MainTabBarController.swift */; };
@@ -304,6 +308,10 @@
 		61C21D0528C4C971009B5F4E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		61E3087B287334C1001394B6 /* ImageScaleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageScaleType.swift; sourceTree = "<group>"; };
 		61E3088328768D71001394B6 /* UIStackView+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Ext.swift"; sourceTree = "<group>"; };
+		61E87EB628D189390005CAA6 /* FeedSearchInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchInteractor.swift; sourceTree = "<group>"; };
+		61E87EB828D1894A0005CAA6 /* FeedSearchPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchPresenter.swift; sourceTree = "<group>"; };
+		61E87EBA28D189570005CAA6 /* FeedSearchWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchWorker.swift; sourceTree = "<group>"; };
+		61E87EBC28D189640005CAA6 /* FeedSearchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchRouter.swift; sourceTree = "<group>"; };
 		61FC60E527B9244D00A51DBC /* KnockKnock-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "KnockKnock-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61FC60E827B9244D00A51DBC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61FC60EA27B9244E00A51DBC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -599,6 +607,10 @@
 			children = (
 				618D8B5828BDA11000828794 /* Views */,
 				618D8B5928BDA12500828794 /* FeedSearchViewController.swift */,
+				61E87EB628D189390005CAA6 /* FeedSearchInteractor.swift */,
+				61E87EB828D1894A0005CAA6 /* FeedSearchPresenter.swift */,
+				61E87EBA28D189570005CAA6 /* FeedSearchWorker.swift */,
+				61E87EBC28D189640005CAA6 /* FeedSearchRouter.swift */,
 			);
 			path = FeedSearch;
 			sourceTree = "<group>";
@@ -967,6 +979,7 @@
 				61215AE428577933003FDCAA /* FeedCell.swift in Sources */,
 				618D8B4D28BC61A100828794 /* BottomSheetOption.swift in Sources */,
 				61AB2E5D28A6257E00A1AE30 /* TapCell.swift in Sources */,
+				61E87EB928D1894A0005CAA6 /* FeedSearchPresenter.swift in Sources */,
 				201077FC27D3D26E00280991 /* BaseTableViewCell.swift in Sources */,
 				617F9D71282BAC1300C2BC9A /* BottomSheetViewController.swift in Sources */,
 				2010780227D3D59F00280991 /* UITableViewCell+Ext.swift in Sources */,
@@ -982,7 +995,9 @@
 				6105079628B4EE9F00C1B5CF /* HomeRouter.swift in Sources */,
 				20EAE2972814054F009242A1 /* ChellengeRepository.swift in Sources */,
 				618FDAC527E80C6B00C2823F /* ShopSearchViewController.swift in Sources */,
+				61E87EBD28D189640005CAA6 /* FeedSearchRouter.swift in Sources */,
 				61A8DC572881B173000512EC /* UIViewController+Ext.swift in Sources */,
+				61E87EBB28D189570005CAA6 /* FeedSearchWorker.swift in Sources */,
 				613856C92895554100BE347E /* FeedDetailRouter.swift in Sources */,
 				61FC60ED27B9244E00A51DBC /* MainTabBarController.swift in Sources */,
 				201077EF27D39FFB00280991 /* Challenge.swift in Sources */,
@@ -1036,6 +1051,7 @@
 				61A8DC47287E905B000512EC /* CommentView.swift in Sources */,
 				613856C7289554E600BE347E /* FeedDetailWorker.swift in Sources */,
 				6143296628642745008BDCC9 /* UILabel+Ext.swift in Sources */,
+				61E87EB728D189390005CAA6 /* FeedSearchInteractor.swift in Sources */,
 				20D28F8427CFC60900A809DB /* ChallengeRouter.swift in Sources */,
 				61A8DC4A287E90BC000512EC /* CommentViewController.swift in Sources */,
 				6105079828B4EEA800C1B5CF /* HomeInteractor.swift in Sources */,

--- a/KnockKnock-iOS.xcodeproj/project.pbxproj
+++ b/KnockKnock-iOS.xcodeproj/project.pbxproj
@@ -106,7 +106,7 @@
 		618D8B4D28BC61A100828794 /* BottomSheetOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D8B4C28BC61A100828794 /* BottomSheetOption.swift */; };
 		618D8B5A28BDA12500828794 /* FeedSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D8B5928BDA12500828794 /* FeedSearchViewController.swift */; };
 		618D8B5C28BDA12F00828794 /* FeedSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D8B5B28BDA12F00828794 /* FeedSearchView.swift */; };
-		618D8B6028BDF6C900828794 /* HomeTapViewTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D8B5F28BDF6C900828794 /* HomeTapViewTag.swift */; };
+		618D8B6028BDF6C900828794 /* SearchTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D8B5F28BDF6C900828794 /* SearchTap.swift */; };
 		618D8B6228BDF8E500828794 /* SearchResultPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D8B6128BDF8E500828794 /* SearchResultPageCell.swift */; };
 		618D8B6428BDFD3200828794 /* SearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D8B6328BDFD3200828794 /* SearchResultCell.swift */; };
 		618D8B6728BE518B00828794 /* FeedSearchResultHeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D8B6628BE518B00828794 /* FeedSearchResultHeaderReusableView.swift */; };
@@ -157,7 +157,7 @@
 		61E87EB928D1894A0005CAA6 /* FeedSearchPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EB828D1894A0005CAA6 /* FeedSearchPresenter.swift */; };
 		61E87EBB28D189570005CAA6 /* FeedSearchWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EBA28D189570005CAA6 /* FeedSearchWorker.swift */; };
 		61E87EBD28D189640005CAA6 /* FeedSearchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EBC28D189640005CAA6 /* FeedSearchRouter.swift */; };
-		61E87EBF28D1A1F20005CAA6 /* SearchLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EBE28D1A1F20005CAA6 /* SearchLog.swift */; };
+		61E87EBF28D1A1F20005CAA6 /* SearchKeyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EBE28D1A1F20005CAA6 /* SearchKeyword.swift */; };
 		61FC60E927B9244D00A51DBC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60E827B9244D00A51DBC /* AppDelegate.swift */; };
 		61FC60EB27B9244E00A51DBC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60EA27B9244E00A51DBC /* SceneDelegate.swift */; };
 		61FC60ED27B9244E00A51DBC /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC60EC27B9244E00A51DBC /* MainTabBarController.swift */; };
@@ -264,7 +264,7 @@
 		618D8B4C28BC61A100828794 /* BottomSheetOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetOption.swift; sourceTree = "<group>"; };
 		618D8B5928BDA12500828794 /* FeedSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchViewController.swift; sourceTree = "<group>"; };
 		618D8B5B28BDA12F00828794 /* FeedSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchView.swift; sourceTree = "<group>"; };
-		618D8B5F28BDF6C900828794 /* HomeTapViewTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTapViewTag.swift; sourceTree = "<group>"; };
+		618D8B5F28BDF6C900828794 /* SearchTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTap.swift; sourceTree = "<group>"; };
 		618D8B6128BDF8E500828794 /* SearchResultPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultPageCell.swift; sourceTree = "<group>"; };
 		618D8B6328BDFD3200828794 /* SearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCell.swift; sourceTree = "<group>"; };
 		618D8B6628BE518B00828794 /* FeedSearchResultHeaderReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchResultHeaderReusableView.swift; sourceTree = "<group>"; };
@@ -313,7 +313,7 @@
 		61E87EB828D1894A0005CAA6 /* FeedSearchPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchPresenter.swift; sourceTree = "<group>"; };
 		61E87EBA28D189570005CAA6 /* FeedSearchWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchWorker.swift; sourceTree = "<group>"; };
 		61E87EBC28D189640005CAA6 /* FeedSearchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSearchRouter.swift; sourceTree = "<group>"; };
-		61E87EBE28D1A1F20005CAA6 /* SearchLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLog.swift; sourceTree = "<group>"; };
+		61E87EBE28D1A1F20005CAA6 /* SearchKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeyword.swift; sourceTree = "<group>"; };
 		61FC60E527B9244D00A51DBC /* KnockKnock-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "KnockKnock-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61FC60E827B9244D00A51DBC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61FC60EA27B9244E00A51DBC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -348,7 +348,7 @@
 				6143296728644187008BDCC9 /* Feed.swift */,
 				619DEE9B28868E7E00C80095 /* Comment.swift */,
 				613856CC2898B64000BE347E /* Like.swift */,
-				61E87EBE28D1A1F20005CAA6 /* SearchLog.swift */,
+				61E87EBE28D1A1F20005CAA6 /* SearchKeyword.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -780,7 +780,7 @@
 				61E3087B287334C1001394B6 /* ImageScaleType.swift */,
 				61B6D997288C40BF00E60F08 /* HomeSection.swift */,
 				616EB090289154B8001BD18C /* FeedDetailSection.swift */,
-				618D8B5F28BDF6C900828794 /* HomeTapViewTag.swift */,
+				618D8B5F28BDF6C900828794 /* SearchTap.swift */,
 				618D8B4C28BC61A100828794 /* BottomSheetOption.swift */,
 			);
 			path = Enum;
@@ -1076,7 +1076,7 @@
 				616EB08B28910485001BD18C /* PostHeaderReusableView.swift in Sources */,
 				618D8B5A28BDA12500828794 /* FeedSearchViewController.swift in Sources */,
 				6143297A28687B74008BDCC9 /* FeedListPresenter.swift in Sources */,
-				61E87EBF28D1A1F20005CAA6 /* SearchLog.swift in Sources */,
+				61E87EBF28D1A1F20005CAA6 /* SearchKeyword.swift in Sources */,
 				618FDAC927E836BA00C2823F /* PhotoCell.swift in Sources */,
 				61AB2E5428A3775300A1AE30 /* Double+Ext.swift in Sources */,
 				61B6D998288C40BF00E60F08 /* HomeSection.swift in Sources */,
@@ -1113,7 +1113,7 @@
 				61AB2E4828A0A7E900A1AE30 /* HomeTagCell.swift in Sources */,
 				6143294D285DD2A0008BDCC9 /* FeedMainFooterCollectionReusableView.swift in Sources */,
 				611BD4A527E3080B007D5C79 /* FeedWriteView.swift in Sources */,
-				618D8B6028BDF6C900828794 /* HomeTapViewTag.swift in Sources */,
+				618D8B6028BDF6C900828794 /* SearchTap.swift in Sources */,
 				201077F827D3BF4B00280991 /* Array+Ext.swift in Sources */,
 				20D28F8627CFC7B300A809DB /* ChallengeWorker.swift in Sources */,
 				611BD4B827E6DD5F007D5C79 /* PropertyCell.swift in Sources */,

--- a/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "22907832079d808e82f1182b21af58ef3880666f",
-        "version" : "7.8.0"
+        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
+        "version" : "7.9.0"
       }
     },
     {

--- a/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "7f31a43f8c49bd4a1723bc9fecdfaa4411dd9f36",
-        "version" : "9.5.0"
+        "revision" : "7e80c25b51c2ffa238879b07fbfc5baa54bb3050",
+        "version" : "9.6.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "f54f60d0164d887e1174fa51ab2efe48a8e9d178",
-        "version" : "9.3.0"
+        "revision" : "c1cfde8067668027b23a42c29d11c246152fe046",
+        "version" : "9.6.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "f4abe56ce62a779e64b525eb133c8fc2a84bbc1f",
-        "version" : "7.7.1"
+        "revision" : "22907832079d808e82f1182b21af58ef3880666f",
+        "version" : "7.8.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "19605024d59eaefdb1f6a2cb11ebe75df4421126",
-        "version" : "2.0.0"
+        "revision" : "d4289da23e978f37c344ea6a386e5546e2466294",
+        "version" : "2.1.0"
       }
     },
     {

--- a/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "b8230909dedc640294d7324d37f4c91ad3dcf177",
-        "version" : "1.20.1"
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
       }
     }
   ],

--- a/KnockKnock-iOS/Entity/SearchKeyword.swift
+++ b/KnockKnock-iOS/Entity/SearchKeyword.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct SearchLog {
-  let regDate: Date
+struct SearchKeyword {
+//  let regDate: Date
   let category: String
   let keyword: String
 }

--- a/KnockKnock-iOS/Entity/SearchLog.swift
+++ b/KnockKnock-iOS/Entity/SearchLog.swift
@@ -1,0 +1,14 @@
+//
+//  SearchLog.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2022/09/14.
+//
+
+import Foundation
+
+struct SearchLog {
+  let regDate: Date
+  let category: String
+  let keyword: String
+}

--- a/KnockKnock-iOS/Enum/SearchTap.swift
+++ b/KnockKnock-iOS/Enum/SearchTap.swift
@@ -13,4 +13,3 @@ enum SearchTap: String, CaseIterable {
   case tag = "태그"
   case place = "장소"
 }
-

--- a/KnockKnock-iOS/Repository/FeedRepository.swift
+++ b/KnockKnock-iOS/Repository/FeedRepository.swift
@@ -33,7 +33,8 @@ final class FeedRepository: FeedRepositoryProtocol {
       currentPage: Int,
       totalCount: Int,
       challengeId: Int,
-      completionHandler: @escaping (FeedMain) -> Void) {
+      completionHandler: @escaping (FeedMain) -> Void
+    ) {
         
       KKNetworkManager.shared
         .request(

--- a/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultCell.swift
@@ -45,27 +45,40 @@ final class SearchResultCell: BaseCollectionViewCell {
 
   // MARK: - Bind
 
-  func bind(tap: SearchTap, isLogSection: Bool, keyword: String?) {
+  func bind(tap: SearchTap, isLogSection: Bool, keyword: SearchKeyword) {
     self.imageView.backgroundColor = .white
     self.deleteButton.isHidden = !isLogSection
-    if let keyword = keyword {
-      self.dataLabel.text = keyword
-    }
+      self.dataLabel.text = keyword.keyword
+
+      switch tap {
+      case .popular:
+        let category = SearchTap(rawValue: keyword.category)
+
+        switch category {
+        case .account:
+          self.imageView.image = KKDS.Image.ic_person_24
+
+        case .tag:
+          self.imageView.image = KKDS.Image.ic_search_tag_52
+
+        case .place:
+          self.imageView.image = KKDS.Image.ic_search_location_52
+
+        default:
+          self.imageView.backgroundColor = .gray30
+          self.imageView.image = nil
+        }
+
+      case .account:
+        self.imageView.image = KKDS.Image.ic_person_24
+
+      case .tag:
+        self.imageView.image = KKDS.Image.ic_search_tag_52
+
+      case .place:
+        self.imageView.image = KKDS.Image.ic_search_location_52
+      }
     
-    switch tap {
-    case .popular:
-      self.imageView.backgroundColor = .gray30
-      self.imageView.image = nil
-
-    case .account:
-      self.imageView.image = KKDS.Image.ic_person_24
-
-    case .tag:
-      self.imageView.image = KKDS.Image.ic_search_tag_52
-
-    case .place:
-      self.imageView.image = KKDS.Image.ic_search_location_52
-    }
   }
 
   // MARK: - Configure

--- a/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultCell.swift
@@ -45,9 +45,10 @@ final class SearchResultCell: BaseCollectionViewCell {
 
   // MARK: - Bind
 
-  func bind(tap: SearchTap, isLogSection: Bool) {
+  func bind(tap: SearchTap, isLogSection: Bool, keyword: String) {
     self.imageView.backgroundColor = .white
     self.deleteButton.isHidden = !isLogSection
+    self.dataLabel.text = keyword
 
     switch tap {
     case .popular:

--- a/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultCell.swift
@@ -45,11 +45,13 @@ final class SearchResultCell: BaseCollectionViewCell {
 
   // MARK: - Bind
 
-  func bind(tap: SearchTap, isLogSection: Bool, keyword: String) {
+  func bind(tap: SearchTap, isLogSection: Bool, keyword: String?) {
     self.imageView.backgroundColor = .white
     self.deleteButton.isHidden = !isLogSection
-    self.dataLabel.text = keyword
-
+    if let keyword = keyword {
+      self.dataLabel.text = keyword
+    }
+    
     switch tap {
     case .popular:
       self.imageView.backgroundColor = .gray30

--- a/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultCell.swift
@@ -48,27 +48,13 @@ final class SearchResultCell: BaseCollectionViewCell {
   func bind(tap: SearchTap, isLogSection: Bool, keyword: SearchKeyword) {
     self.imageView.backgroundColor = .white
     self.deleteButton.isHidden = !isLogSection
-      self.dataLabel.text = keyword.keyword
+    self.dataLabel.text = keyword.keyword
 
-      switch tap {
-      case .popular:
-        let category = SearchTap(rawValue: keyword.category)
+    switch tap {
+    case .popular:
+      let category = SearchTap(rawValue: keyword.category)
 
-        switch category {
-        case .account:
-          self.imageView.image = KKDS.Image.ic_person_24
-
-        case .tag:
-          self.imageView.image = KKDS.Image.ic_search_tag_52
-
-        case .place:
-          self.imageView.image = KKDS.Image.ic_search_location_52
-
-        default:
-          self.imageView.backgroundColor = .gray30
-          self.imageView.image = nil
-        }
-
+      switch category {
       case .account:
         self.imageView.image = KKDS.Image.ic_person_24
 
@@ -77,7 +63,21 @@ final class SearchResultCell: BaseCollectionViewCell {
 
       case .place:
         self.imageView.image = KKDS.Image.ic_search_location_52
+
+      default:
+        self.imageView.backgroundColor = .gray30
+        self.imageView.image = nil
       }
+
+    case .account:
+      self.imageView.image = KKDS.Image.ic_person_24
+
+    case .tag:
+      self.imageView.image = KKDS.Image.ic_search_tag_52
+
+    case .place:
+      self.imageView.image = KKDS.Image.ic_search_location_52
+    }
     
   }
 

--- a/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
@@ -26,11 +26,29 @@ final class SearchResultPageCell: BaseCollectionViewCell {
     }
   }
 
-  var searchKeyword: [SearchKeyword] = [] {
+  var searchKeyword: [SearchTap: [SearchKeyword]] = [:] {
     didSet{
+      if let allKeywords = searchKeyword[SearchTap.popular] {
+        self.allKeywords = allKeywords
+      }
+      if let tagKeywords = searchKeyword[SearchTap.tag] {
+        self.tagKeywords = tagKeywords
+      }
+      if let accountKeywords = searchKeyword[SearchTap.account] {
+        self.accountKeywords = accountKeywords
+      }
+      if let placeKeywords = searchKeyword[SearchTap.place] {
+        self.placeKeywords = placeKeywords
+      }
+
       self.searchResultCollectionView.reloadData()
     }
   }
+
+  var allKeywords: [SearchKeyword] = []
+  var tagKeywords: [SearchKeyword] = []
+  var accountKeywords: [SearchKeyword] = []
+  var placeKeywords: [SearchKeyword] = []
 
   // MARK: - UIs
 
@@ -43,7 +61,7 @@ final class SearchResultPageCell: BaseCollectionViewCell {
 
   // MARK: - Bind
 
-  func bind(index: IndexPath, searchKeyword: [SearchKeyword]) {
+  func bind(index: IndexPath, searchKeyword: [SearchTap: [SearchKeyword]]) {
     self.tapIndex = index.row
     self.searchKeyword = searchKeyword
   }
@@ -77,14 +95,21 @@ extension SearchResultPageCell: UICollectionViewDataSource, UICollectionViewDele
     _ collectionView: UICollectionView,
     numberOfItemsInSection section: Int
   ) -> Int {
-    let tap = SearchTap[self.tapIndex]
-    switch tap {
-    case "인기":
+    switch tapIndex {
+    case 0:
       if section == 0 {
         return 3
+      } else {
+        return self.allKeywords.count
       }
+    case 1:
+      return self.accountKeywords.count
+    case 2:
+      return self.tagKeywords.count
+    case 3:
+      return self.placeKeywords.count
     default:
-      return self.searchKeyword.count
+      return 0
     }
   }
 
@@ -104,20 +129,44 @@ extension SearchResultPageCell: UICollectionViewDataSource, UICollectionViewDele
       withType: SearchResultCell.self,
       for: indexPath
     )
-    print(searchKeyword)
-    if indexPath.section == 0 && self.tapIndex == 0 {
-      cell.bind(
-        tap: SearchTap.allCases[self.tapIndex],
-        isLogSection: false,
-        keyword: SearchKeyword(category: "인기", keyword: "용기내칠린지")
-      )
-    } else {
+    
+    switch self.tapIndex {
+    case 0:
+      if indexPath.section == 0 {
+        cell.bind(
+          tap: SearchTap.allCases[self.tapIndex],
+          isLogSection: false,
+          keyword: SearchKeyword(category: "인기", keyword: "용기내챌린지")
+        )
+      } else {
+        cell.bind(
+          tap: SearchTap.allCases[self.tapIndex],
+          isLogSection: true,
+          keyword: self.allKeywords[indexPath.item]
+        )
+      }
+    case 1:
       cell.bind(
         tap: SearchTap.allCases[self.tapIndex],
         isLogSection: true,
-        keyword: self.searchKeyword[indexPath.item]
+        keyword: self.accountKeywords[indexPath.item]
       )
+    case 2:
+      cell.bind(
+        tap: SearchTap.allCases[self.tapIndex],
+        isLogSection: true,
+        keyword: self.tagKeywords[indexPath.item]
+      )
+    case 3:
+      cell.bind(
+        tap: SearchTap.allCases[self.tapIndex],
+        isLogSection: true,
+        keyword: self.placeKeywords[indexPath.item]
+      )
+    default:
+      break
     }
+
     return cell
   }
 
@@ -144,7 +193,19 @@ extension SearchResultPageCell: UICollectionViewDataSource, UICollectionViewDele
         withType: FeedSearchResultHeaderReusableView.self,
         for: indexPath
       )
-    
+
+      switch tapIndex {
+      case 0:
+        header.bind(isEmpty: self.allKeywords.count == 0)
+      case 1:
+        header.bind(isEmpty: self.accountKeywords.count == 0)
+      case 2:
+        header.bind(isEmpty: self.tagKeywords.count == 0)
+      case 3:
+        header.bind(isEmpty: self.placeKeywords.count == 0)
+      default:
+        print("error")
+      }
       return header
 
     case UICollectionView.elementKindSectionFooter:

--- a/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
@@ -26,7 +26,7 @@ final class SearchResultPageCell: BaseCollectionViewCell {
     }
   }
 
-  var searchLog: [SearchLog] = [] {
+  var searchKeyword: [SearchKeyword] = [] {
     didSet{
       self.searchResultCollectionView.reloadData()
     }
@@ -43,9 +43,9 @@ final class SearchResultPageCell: BaseCollectionViewCell {
 
   // MARK: - Bind
 
-  func bind(index: IndexPath, searchLog: [SearchLog]) {
+  func bind(index: IndexPath, searchKeyword: [SearchKeyword]) {
     self.tapIndex = index.row
-    self.searchLog = searchLog
+    self.searchKeyword = searchKeyword
   }
 
   // MARK: - Configure
@@ -77,10 +77,14 @@ extension SearchResultPageCell: UICollectionViewDataSource, UICollectionViewDele
     _ collectionView: UICollectionView,
     numberOfItemsInSection section: Int
   ) -> Int {
-    if section == 0 && self.tapIndex == 0 {
-      return 3
-    } else {
-      return self.searchLog.count
+    let tap = SearchTap[self.tapIndex]
+    switch tap {
+    case "인기":
+      if section == 0 {
+        return 3
+      }
+    default:
+      return self.searchKeyword.count
     }
   }
 
@@ -100,11 +104,19 @@ extension SearchResultPageCell: UICollectionViewDataSource, UICollectionViewDele
       withType: SearchResultCell.self,
       for: indexPath
     )
-    cell.backgroundColor = .white
+    print(searchKeyword)
     if indexPath.section == 0 && self.tapIndex == 0 {
-      cell.bind(tap: SearchTap.allCases[self.tapIndex], isLogSection: false, keyword: nil)
+      cell.bind(
+        tap: SearchTap.allCases[self.tapIndex],
+        isLogSection: false,
+        keyword: SearchKeyword(category: "인기", keyword: "용기내칠린지")
+      )
     } else {
-      cell.bind(tap: SearchTap.allCases[self.tapIndex], isLogSection: true, keyword: self.searchLog[indexPath.item].keyword)
+      cell.bind(
+        tap: SearchTap.allCases[self.tapIndex],
+        isLogSection: true,
+        keyword: self.searchKeyword[indexPath.item]
+      )
     }
     return cell
   }

--- a/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
@@ -104,10 +104,13 @@ extension SearchResultPageCell: UICollectionViewDataSource, UICollectionViewDele
       }
     case 1:
       return self.accountKeywords.count
+
     case 2:
       return self.tagKeywords.count
+
     case 3:
       return self.placeKeywords.count
+      
     default:
       return 0
     }

--- a/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
@@ -26,6 +26,12 @@ final class SearchResultPageCell: BaseCollectionViewCell {
     }
   }
 
+  var searchLog: [SearchLog] = [] {
+    didSet{
+      self.searchResultCollectionView.reloadData()
+    }
+  }
+
   // MARK: - UIs
 
   let searchResultCollectionView = UICollectionView(

--- a/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedSearch/SearchResultPageCell.swift
@@ -43,8 +43,9 @@ final class SearchResultPageCell: BaseCollectionViewCell {
 
   // MARK: - Bind
 
-  func bind(index: IndexPath) {
+  func bind(index: IndexPath, searchLog: [SearchLog]) {
     self.tapIndex = index.row
+    self.searchLog = searchLog
   }
 
   // MARK: - Configure
@@ -76,7 +77,11 @@ extension SearchResultPageCell: UICollectionViewDataSource, UICollectionViewDele
     _ collectionView: UICollectionView,
     numberOfItemsInSection section: Int
   ) -> Int {
-    return 3
+    if section == 0 && self.tapIndex == 0 {
+      return 3
+    } else {
+      return self.searchLog.count
+    }
   }
 
   func numberOfSections(in collectionView: UICollectionView) -> Int {
@@ -97,9 +102,9 @@ extension SearchResultPageCell: UICollectionViewDataSource, UICollectionViewDele
     )
     cell.backgroundColor = .white
     if indexPath.section == 0 && self.tapIndex == 0 {
-      cell.bind(tap: SearchTap.allCases[self.tapIndex], isLogSection: false)
+      cell.bind(tap: SearchTap.allCases[self.tapIndex], isLogSection: false, keyword: nil)
     } else {
-      cell.bind(tap: SearchTap.allCases[self.tapIndex], isLogSection: true)
+      cell.bind(tap: SearchTap.allCases[self.tapIndex], isLogSection: true, keyword: self.searchLog[indexPath.item].keyword)
     }
     return cell
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -14,7 +14,8 @@ protocol FeedMainInteractorProtocol {
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int)
   func fetchChallengeTitles()
   func setSelectedStatus(challengeTitles: [ChallengeTitle], selectedIndex: IndexPath)
-  func saveSearchLog(searchKeyword: [SearchKeyword])
+
+  func saveSearchKeyword(searchKeyword: [SearchKeyword])
 }
 
 final class FeedMainInteractor: FeedMainInteractorProtocol {
@@ -24,8 +25,8 @@ final class FeedMainInteractor: FeedMainInteractorProtocol {
   var presenter: FeedMainPresenterProtocol?
   var worker: FeedMainWorkerProtocol?
 
-  func saveSearchLog(searchKeyword: [SearchKeyword]) {
-    self.worker?.saveSearchLog(searchKeyword: searchKeyword)
+  func saveSearchKeyword(searchKeyword: [SearchKeyword]) {
+    self.worker?.saveSearchKeyword(searchKeyword: searchKeyword)
   }
 
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int) {

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -15,7 +15,6 @@ protocol FeedMainInteractorProtocol {
   func fetchChallengeTitles()
   func setSelectedStatus(challengeTitles: [ChallengeTitle], selectedIndex: IndexPath)
   func saveSearchLog(searchLog: [SearchLog])
-  func getSearchLog()
 }
 
 final class FeedMainInteractor: FeedMainInteractorProtocol {
@@ -27,12 +26,6 @@ final class FeedMainInteractor: FeedMainInteractorProtocol {
 
   func saveSearchLog(searchLog: [SearchLog]) {
     self.worker?.saveSearchLog(searchLog: searchLog)
-  }
-
-  func getSearchLog() {
-    self.worker?.getSearchLog { [weak self] log in
-      self?.presenter?.presentSearchLog(searchLog: log)
-    }
   }
 
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int) {

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -14,7 +14,7 @@ protocol FeedMainInteractorProtocol {
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int)
   func fetchChallengeTitles()
   func setSelectedStatus(challengeTitles: [ChallengeTitle], selectedIndex: IndexPath)
-  func saveSearchLog(searchLog: [SearchLog])
+  func saveSearchLog(searchKeyword: [SearchKeyword])
 }
 
 final class FeedMainInteractor: FeedMainInteractorProtocol {
@@ -24,8 +24,8 @@ final class FeedMainInteractor: FeedMainInteractorProtocol {
   var presenter: FeedMainPresenterProtocol?
   var worker: FeedMainWorkerProtocol?
 
-  func saveSearchLog(searchLog: [SearchLog]) {
-    self.worker?.saveSearchLog(searchLog: searchLog)
+  func saveSearchLog(searchKeyword: [SearchKeyword]) {
+    self.worker?.saveSearchLog(searchKeyword: searchKeyword)
   }
 
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int) {

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -14,7 +14,7 @@ protocol FeedMainInteractorProtocol {
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int)
   func fetchChallengeTitles()
   func setSelectedStatus(challengeTitles: [ChallengeTitle], selectedIndex: IndexPath)
-  func saveSearchLog(searchLog: SearchLog)
+  func saveSearchLog(searchLog: [SearchLog])
   func getSearchLog()
 }
 
@@ -25,13 +25,13 @@ final class FeedMainInteractor: FeedMainInteractorProtocol {
   var presenter: FeedMainPresenterProtocol?
   var worker: FeedMainWorkerProtocol?
 
-  func saveSearchLog(searchLog: SearchLog) {
+  func saveSearchLog(searchLog: [SearchLog]) {
     self.worker?.saveSearchLog(searchLog: searchLog)
   }
 
   func getSearchLog() {
-    self.worker?.getSearchLog { [weak self] logs in
-      self?.presenter?.presentSearchLog(searchLog: logs)
+    self.worker?.getSearchLog { [weak self] log in
+      self?.presenter?.presentSearchLog(searchLog: log)
     }
   }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -14,6 +14,8 @@ protocol FeedMainInteractorProtocol {
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int)
   func fetchChallengeTitles()
   func setSelectedStatus(challengeTitles: [ChallengeTitle], selectedIndex: IndexPath)
+  func saveSearchLog(searchLog: SearchLog)
+  func getSearchLog()
 }
 
 final class FeedMainInteractor: FeedMainInteractorProtocol {
@@ -22,6 +24,16 @@ final class FeedMainInteractor: FeedMainInteractorProtocol {
   
   var presenter: FeedMainPresenterProtocol?
   var worker: FeedMainWorkerProtocol?
+
+  func saveSearchLog(searchLog: SearchLog) {
+    self.worker?.saveSearchLog(searchLog: searchLog)
+  }
+
+  func getSearchLog() {
+    self.worker?.getSearchLog { [weak self] logs in
+      self?.presenter?.presentSearchLog(searchLog: logs)
+    }
+  }
 
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int) {
     self.worker?.fetchFeedMain(

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
@@ -12,6 +12,7 @@ protocol FeedMainPresenterProtocol {
   
   func presentFeedMain(feed: FeedMain)
   func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?)
+  func presentSearchLog(searchLog: [SearchLog])
 }
 
 final class FeedMainPresenter: FeedMainPresenterProtocol {
@@ -27,4 +28,9 @@ final class FeedMainPresenter: FeedMainPresenterProtocol {
   func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?) {
     self.view?.fetchChallengeTitles(challengeTitle: challengeTitle, index: index)
   }
+
+  func presentSearchLog(searchLog: [SearchLog]) {
+    self.view?.fetchSearchLog(searchLog: searchLog)
+  }
+
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
@@ -12,7 +12,7 @@ protocol FeedMainPresenterProtocol {
   
   func presentFeedMain(feed: FeedMain)
   func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?)
-  func presentSearchLog(searchLog: [SearchLog])
+
 }
 
 final class FeedMainPresenter: FeedMainPresenterProtocol {
@@ -29,8 +29,5 @@ final class FeedMainPresenter: FeedMainPresenterProtocol {
     self.view?.fetchChallengeTitles(challengeTitle: challengeTitle, index: index)
   }
 
-  func presentSearchLog(searchLog: [SearchLog]) {
-    self.view?.fetchSearchLog(searchLog: searchLog)
-  }
 
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
@@ -28,6 +28,4 @@ final class FeedMainPresenter: FeedMainPresenterProtocol {
   func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?) {
     self.view?.fetchChallengeTitles(challengeTitle: challengeTitle, index: index)
   }
-
-
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainRouter.swift
@@ -9,10 +9,12 @@ import UIKit
 
 protocol FeedMainRouterProtocol {
   static func createFeed() -> UIViewController
+
   func navigateToFeedList(source: FeedMainViewProtocol)
+  func passDataToFeedSearch(source: FeedMainViewProtocol)
 }
 
-final class FeedMainRouter {
+final class FeedMainRouter: FeedMainRouterProtocol {
 
   static func createFeed() -> UIViewController {
     let view = FeedMainViewController()
@@ -29,9 +31,11 @@ final class FeedMainRouter {
 
     return view
   }
-}
 
-extension FeedMainRouter: FeedMainRouterProtocol {
+  func passDataToFeedSearch(source: FeedMainViewProtocol) {
+    
+  }
+
   func navigateToFeedList(source: FeedMainViewProtocol) {
     let feedListViewController = FeedListRouter.createFeedList()
     if let sourceView = source as? UIViewController {

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainRouter.swift
@@ -11,7 +11,6 @@ protocol FeedMainRouterProtocol {
   static func createFeed() -> UIViewController
 
   func navigateToFeedList(source: FeedMainViewProtocol)
-  func passDataToFeedSearch(source: FeedMainViewProtocol)
 }
 
 final class FeedMainRouter: FeedMainRouterProtocol {
@@ -30,10 +29,6 @@ final class FeedMainRouter: FeedMainRouterProtocol {
     presenter.view = view
 
     return view
-  }
-
-  func passDataToFeedSearch(source: FeedMainViewProtocol) {
-    
   }
 
   func navigateToFeedList(source: FeedMainViewProtocol) {

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -37,12 +37,28 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
     }
   }
   var challengeTitles: [ChallengeTitle] = []
-  private var searchLogs: [SearchLog] = []
+  var searchLogs: [SearchLog] = [] {
+    didSet {
+      self.navigationItem.searchController?.searchResultsController?.viewDidLoad()
+    }
+  }
 
   var currentPage = 1
   let pageSize = 1 // pageSize 논의 필요, 페이지네이션 작동 테스트를 위해 1로 임시 설정
   var challengeId = 0
-  
+
+  // MARK: - UIs
+
+  let searchBar = UISearchController(
+    searchResultsController: FeedSearchRouter.createFeedSearch(searchLog: searchLogs)
+  ).then {
+    $0.hidesNavigationBarDuringPresentation = false
+    $0.showsSearchResultsController = true
+    $0.searchBar.placeholder = "검색어를 입력하세요."
+    $0.searchBar.tintColor = .black
+    $0.searchBar.setValue("취소", forKey: "cancelButtonText")
+  }
+
   // MARK: - Lify Cycles
   
   override func viewDidLoad() {
@@ -67,8 +83,9 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
   
   override func setupConfigure() {
 
-    self.navigationItem.searchController = containerView.searchBar
+    self.navigationItem.searchController = searchBar
     self.navigationItem.searchController?.searchBar.searchTextField.delegate = self
+//    self.navigationItem.searchController?.searchResultsUpdater = self
 
     self.containerView.tagCollectionView.do {
       $0.delegate = self
@@ -140,11 +157,10 @@ extension FeedMainViewController: UISearchTextFieldDelegate {
   func textFieldDidEndEditing(_ textField: UITextField) {
     if let keyword = textField.text {
       let log = SearchLog(regDate: Date(), category: "인기", keyword: keyword)
-      self.interactor?.saveSearchLog(searchLog: log)
-      self.interactor?.getSearchLog()
-
-      print(searchLogs)
+      self.searchLogs.append(log)
+      self.interactor?.saveSearchLog(searchLog: self.searchLogs)
     }
+    self.interactor?.getSearchLog()
   }
 }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -9,9 +9,10 @@ import UIKit
 
 protocol FeedMainViewProtocol: AnyObject {
   var interactor: FeedMainInteractorProtocol? { get set }
-  
+
   func fetchFeedMain(feed: FeedMain)
   func fetchChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?)
+  func fetchSearchLog(searchLog: [SearchLog])
 }
 
 final class FeedMainViewController: BaseViewController<FeedMainView> {
@@ -36,7 +37,8 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
     }
   }
   var challengeTitles: [ChallengeTitle] = []
-  
+  private var searchLogs: [SearchLog] = []
+
   var currentPage = 1
   let pageSize = 1 // pageSize 논의 필요, 페이지네이션 작동 테스트를 위해 1로 임시 설정
   var challengeId = 0
@@ -64,8 +66,10 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
   // MARK: - Configure
   
   override func setupConfigure() {
+
     self.navigationItem.searchController = containerView.searchBar
-    
+    self.navigationItem.searchController?.searchBar.searchTextField.delegate = self
+
     self.containerView.tagCollectionView.do {
       $0.delegate = self
       $0.dataSource = self
@@ -104,7 +108,11 @@ extension FeedMainViewController: FeedMainViewProtocol {
       self.feedMainPost.append($0)
     }
   }
-  
+
+  func fetchSearchLog(searchLog: [SearchLog]) {
+    self.searchLogs = searchLog
+  }
+
   func fetchChallengeTitles(
     challengeTitle: [ChallengeTitle],
     index: IndexPath?
@@ -121,6 +129,21 @@ extension FeedMainViewController: FeedMainViewProtocol {
       }
     } else {
       self.containerView.tagCollectionView.reloadData()
+    }
+  }
+}
+
+// MARK: - SearchTextField Delegate
+
+extension FeedMainViewController: UISearchTextFieldDelegate {
+
+  func textFieldDidEndEditing(_ textField: UITextField) {
+    if let keyword = textField.text {
+      let log = SearchLog(regDate: Date(), category: "인기", keyword: keyword)
+      self.interactor?.saveSearchLog(searchLog: log)
+      self.interactor?.getSearchLog()
+
+      print(searchLogs)
     }
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -51,6 +51,8 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
   ).then {
     $0.hidesNavigationBarDuringPresentation = false
     $0.showsSearchResultsController = true
+
+    $0.searchBar.delegate = self
     $0.searchBar.placeholder = "검색어를 입력하세요."
     $0.searchBar.tintColor = .black
     $0.searchBar.setValue("취소", forKey: "cancelButtonText")
@@ -75,13 +77,12 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
   }
-  
+
   // MARK: - Configure
   
   override func setupConfigure() {
 
     self.navigationItem.searchController = searchBar
-    self.navigationItem.searchController?.searchBar.searchTextField.delegate = self
 
     self.containerView.tagCollectionView.do {
       $0.delegate = self
@@ -147,11 +148,9 @@ extension FeedMainViewController: FeedMainViewProtocol {
 }
 
 // MARK: - SearchTextField Delegate
-
-extension FeedMainViewController: UISearchTextFieldDelegate {
-
-  func textFieldDidEndEditing(_ textField: UITextField) {
-    if let keyword = textField.text {
+extension FeedMainViewController: UISearchBarDelegate {
+  func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+    if let keyword = searchBar.searchTextField.text {
       let searchLog = SearchKeyword(category: "계정", keyword: keyword)
       self.searchKeyword.append(searchLog)
       self.interactor?.saveSearchKeyword(searchKeyword: self.searchKeyword)

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -12,7 +12,7 @@ protocol FeedMainViewProtocol: AnyObject {
 
   func fetchFeedMain(feed: FeedMain)
   func fetchChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?)
-  func fetchSearchLog(searchLog: [SearchLog])
+  func fetchSearchLog(searchKeyword: [SearchKeyword])
 }
 
 final class FeedMainViewController: BaseViewController<FeedMainView> {
@@ -37,7 +37,7 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
     }
   }
   var challengeTitles: [ChallengeTitle] = []
-  var searchLogs: [SearchLog] = []
+  var searchKeyword: [SearchKeyword] = []
   var popularPost: [String] = []
   
   var currentPage = 1
@@ -122,8 +122,8 @@ extension FeedMainViewController: FeedMainViewProtocol {
     }
   }
 
-  func fetchSearchLog(searchLog: [SearchLog]) {
-    self.searchLogs = searchLog
+  func fetchSearchLog(searchKeyword: [SearchKeyword]) {
+    self.searchKeyword = searchKeyword
   }
 
   func fetchChallengeTitles(
@@ -152,9 +152,9 @@ extension FeedMainViewController: UISearchTextFieldDelegate {
 
   func textFieldDidEndEditing(_ textField: UITextField) {
     if let keyword = textField.text {
-      let log = SearchLog(regDate: Date(), category: "인기", keyword: keyword)
-      self.searchLogs.append(log)
-      self.interactor?.saveSearchLog(searchLog: self.searchLogs)
+      let searchLog = SearchKeyword(category: "태그", keyword: keyword)
+      self.searchKeyword.append(searchLog)
+      self.interactor?.saveSearchLog(searchKeyword: self.searchKeyword)
     }
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -152,7 +152,7 @@ extension FeedMainViewController: UISearchTextFieldDelegate {
 
   func textFieldDidEndEditing(_ textField: UITextField) {
     if let keyword = textField.text {
-      let searchLog = SearchKeyword(category: "태그", keyword: keyword)
+      let searchLog = SearchKeyword(category: "계정", keyword: keyword)
       self.searchKeyword.append(searchLog)
       self.interactor?.saveSearchLog(searchKeyword: self.searchKeyword)
     }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -154,7 +154,7 @@ extension FeedMainViewController: UISearchTextFieldDelegate {
     if let keyword = textField.text {
       let searchLog = SearchKeyword(category: "계정", keyword: keyword)
       self.searchKeyword.append(searchLog)
-      self.interactor?.saveSearchLog(searchKeyword: self.searchKeyword)
+      self.interactor?.saveSearchKeyword(searchKeyword: self.searchKeyword)
     }
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -37,20 +37,17 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
     }
   }
   var challengeTitles: [ChallengeTitle] = []
-  var searchLogs: [SearchLog] = [] {
-    didSet {
-      self.navigationItem.searchController?.searchResultsController?.viewDidLoad()
-    }
-  }
-
+  var searchLogs: [SearchLog] = []
+  var popularPost: [String] = []
+  
   var currentPage = 1
   let pageSize = 1 // pageSize 논의 필요, 페이지네이션 작동 테스트를 위해 1로 임시 설정
   var challengeId = 0
 
   // MARK: - UIs
 
-  let searchBar = UISearchController(
-    searchResultsController: FeedSearchRouter.createFeedSearch(searchLog: searchLogs)
+  lazy var searchBar = UISearchController(
+    searchResultsController: FeedSearchRouter.createFeedSearch()
   ).then {
     $0.hidesNavigationBarDuringPresentation = false
     $0.showsSearchResultsController = true
@@ -85,7 +82,6 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
 
     self.navigationItem.searchController = searchBar
     self.navigationItem.searchController?.searchBar.searchTextField.delegate = self
-//    self.navigationItem.searchController?.searchResultsUpdater = self
 
     self.containerView.tagCollectionView.do {
       $0.delegate = self
@@ -160,7 +156,6 @@ extension FeedMainViewController: UISearchTextFieldDelegate {
       self.searchLogs.append(log)
       self.interactor?.saveSearchLog(searchLog: self.searchLogs)
     }
-    self.interactor?.getSearchLog()
   }
 }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
@@ -11,7 +11,7 @@ protocol FeedMainWorkerProtocol: AnyObject {
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int, completionHandler: @escaping (FeedMain) -> Void)
   func fetchChallengeTitles(completionHandler: @escaping ([ChallengeTitle]) -> Void)
   
-  func saveSearchLog(searchLog: SearchLog)
+  func saveSearchLog(searchLog: [SearchLog])
   func getSearchLog(completionHandler: @escaping ([SearchLog]) -> Void)
 }
 
@@ -24,12 +24,14 @@ final class FeedMainWorker: FeedMainWorkerProtocol {
     self.repository = repository
   }
 
-  func saveSearchLog(searchLog: SearchLog) {
-    let log: [String: Any] = [
-      "regDate": searchLog.regDate,
-      "keyword": searchLog.keyword,
-      "category": searchLog.category
-    ]
+  func saveSearchLog(searchLog: [SearchLog]) {
+    let log = searchLog.map {
+      [
+        "regDate": $0.regDate,
+        "keyword": $0.keyword,
+        "category": $0.category
+      ]
+    }
     userDefaults.set(log, forKey: "searchLog")
   }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
@@ -11,7 +11,7 @@ protocol FeedMainWorkerProtocol: AnyObject {
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int, completionHandler: @escaping (FeedMain) -> Void)
   func fetchChallengeTitles(completionHandler: @escaping ([ChallengeTitle]) -> Void)
   
-  func saveSearchLog(searchKeyword: [SearchKeyword])
+  func saveSearchKeyword(searchKeyword: [SearchKeyword])
 }
 
 final class FeedMainWorker: FeedMainWorkerProtocol {
@@ -23,14 +23,15 @@ final class FeedMainWorker: FeedMainWorkerProtocol {
     self.repository = repository
   }
 
-  func saveSearchLog(searchKeyword: [SearchKeyword]) {
-    let log = searchKeyword.map {
+  func saveSearchKeyword(searchKeyword: [SearchKeyword]) {
+    let keyword = searchKeyword.map {
       [
         "keyword": $0.keyword,
         "category": $0.category
       ]
     }
-    userDefaults.set(log, forKey: "searchLog")
+    userDefaults.set(keyword, forKey: "searchLog")
+    print("저장완료")
   }
 
   func fetchFeedMain(

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
@@ -11,7 +11,7 @@ protocol FeedMainWorkerProtocol: AnyObject {
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int, completionHandler: @escaping (FeedMain) -> Void)
   func fetchChallengeTitles(completionHandler: @escaping ([ChallengeTitle]) -> Void)
   
-  func saveSearchLog(searchLog: [SearchLog])
+  func saveSearchLog(searchKeyword: [SearchKeyword])
 }
 
 final class FeedMainWorker: FeedMainWorkerProtocol {
@@ -23,10 +23,10 @@ final class FeedMainWorker: FeedMainWorkerProtocol {
     self.repository = repository
   }
 
-  func saveSearchLog(searchLog: [SearchLog]) {
-    let log = searchLog.map {
+  func saveSearchLog(searchKeyword: [SearchKeyword]) {
+    let log = searchKeyword.map {
       [
-        "regDate": $0.regDate,
+//        "regDate": $0.regDate,
         "keyword": $0.keyword,
         "category": $0.category
       ]

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
@@ -10,14 +10,41 @@ import Foundation
 protocol FeedMainWorkerProtocol: AnyObject {
   func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int, completionHandler: @escaping (FeedMain) -> Void)
   func fetchChallengeTitles(completionHandler: @escaping ([ChallengeTitle]) -> Void)
+  
+  func saveSearchLog(searchLog: SearchLog)
+  func getSearchLog(completionHandler: @escaping ([SearchLog]) -> Void)
 }
 
 final class FeedMainWorker: FeedMainWorkerProtocol {
 
   private let repository: FeedRepositoryProtocol
+  private let userDefaults = UserDefaults.standard
 
   init(repository: FeedRepositoryProtocol) {
     self.repository = repository
+  }
+
+  func saveSearchLog(searchLog: SearchLog) {
+    let log: [String: Any] = [
+      "regDate": searchLog.regDate,
+      "keyword": searchLog.keyword,
+      "category": searchLog.category
+    ]
+    userDefaults.set(log, forKey: "searchLog")
+  }
+
+  func getSearchLog(completionHandler: @escaping ([SearchLog]) -> Void) {
+    var searchLog: [SearchLog] = []
+
+    guard let log = userDefaults.object(forKey: "searchLog") as? [[String: Any]] else { return }
+
+    searchLog = log.compactMap {
+      guard let regDate = $0["regDate"] as? Date else { return nil }
+      guard let keyword = $0["keyword"] as? String else { return nil }
+      guard let category = $0["category"] as? String else { return nil }
+      return SearchLog(regDate: regDate, category: category, keyword: keyword)
+    }
+    completionHandler(searchLog)
   }
 
   func fetchFeedMain(

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
@@ -12,7 +12,6 @@ protocol FeedMainWorkerProtocol: AnyObject {
   func fetchChallengeTitles(completionHandler: @escaping ([ChallengeTitle]) -> Void)
   
   func saveSearchLog(searchLog: [SearchLog])
-  func getSearchLog(completionHandler: @escaping ([SearchLog]) -> Void)
 }
 
 final class FeedMainWorker: FeedMainWorkerProtocol {
@@ -33,20 +32,6 @@ final class FeedMainWorker: FeedMainWorkerProtocol {
       ]
     }
     userDefaults.set(log, forKey: "searchLog")
-  }
-
-  func getSearchLog(completionHandler: @escaping ([SearchLog]) -> Void) {
-    var searchLog: [SearchLog] = []
-
-    guard let log = userDefaults.object(forKey: "searchLog") as? [[String: Any]] else { return }
-
-    searchLog = log.compactMap {
-      guard let regDate = $0["regDate"] as? Date else { return nil }
-      guard let keyword = $0["keyword"] as? String else { return nil }
-      guard let category = $0["category"] as? String else { return nil }
-      return SearchLog(regDate: regDate, category: category, keyword: keyword)
-    }
-    completionHandler(searchLog)
   }
 
   func fetchFeedMain(

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
@@ -26,7 +26,6 @@ final class FeedMainWorker: FeedMainWorkerProtocol {
   func saveSearchLog(searchKeyword: [SearchKeyword]) {
     let log = searchKeyword.map {
       [
-//        "regDate": $0.regDate,
         "keyword": $0.keyword,
         "category": $0.category
       ]

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/Views/FeedMainView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/Views/FeedMainView.swift
@@ -34,14 +34,6 @@ class FeedMainView: UIView {
   }
   
   // MARK: - UIs
-  
-  let searchBar = UISearchController(searchResultsController: FeedSearchRouter.createFeedSearch()).then {
-    $0.hidesNavigationBarDuringPresentation = false
-    $0.showsSearchResultsController = true
-    $0.searchBar.placeholder = "검색어를 입력하세요."
-    $0.searchBar.tintColor = .black
-    $0.searchBar.setValue("취소", forKey: "cancelButtonText")
-  }
 
   private let gradientImageView = UIImageView().then {
     $0.translatesAutoresizingMaskIntoConstraints = false

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/Views/FeedMainView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/Views/FeedMainView.swift
@@ -35,7 +35,7 @@ class FeedMainView: UIView {
   
   // MARK: - UIs
   
-  let searchBar = UISearchController(searchResultsController: FeedSearchViewController()).then {
+  let searchBar = UISearchController(searchResultsController: FeedSearchRouter.createFeedSearch()).then {
     $0.hidesNavigationBarDuringPresentation = false
     $0.showsSearchResultsController = true
     $0.searchBar.placeholder = "검색어를 입력하세요."

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchInteractor.swift
@@ -10,9 +10,17 @@ import UIKit
 protocol FeedSearchInteractorProtocol {
   var presenter: FeedSearchPresenterProtocol? { get set }
   var worker: FeedSearchWorkerProtocol? { get set }
+
+  func getSearchLog()
 }
 
 final class FeedSearchInteractor: FeedSearchInteractorProtocol {
   var presenter: FeedSearchPresenterProtocol?
   var worker: FeedSearchWorkerProtocol?
+
+  func getSearchLog() {
+    self.worker?.getSearchLog { [weak self] log in
+      self?.presenter?.presentSearchLog(searchLog: log)
+    }
+  }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchInteractor.swift
@@ -1,0 +1,18 @@
+//
+//  FeedSearchInteractor.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2022/09/14.
+//
+
+import UIKit
+
+protocol FeedSearchInteractorProtocol {
+  var presenter: FeedSearchPresenterProtocol? { get set }
+  var worker: FeedSearchWorkerProtocol? { get set }
+}
+
+final class FeedSearchInteractor: FeedSearchInteractorProtocol {
+  var presenter: FeedSearchPresenterProtocol?
+  var worker: FeedSearchWorkerProtocol?
+}

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchInteractor.swift
@@ -20,7 +20,7 @@ final class FeedSearchInteractor: FeedSearchInteractorProtocol {
 
   func getSearchLog() {
     self.worker?.getSearchLog { [weak self] log in
-      self?.presenter?.presentSearchLog(searchLog: log)
+      self?.presenter?.presentSearchLog(searchKeyword: log)
     }
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchInteractor.swift
@@ -12,6 +12,7 @@ protocol FeedSearchInteractorProtocol {
   var worker: FeedSearchWorkerProtocol? { get set }
 
   func getSearchLog()
+  func distributeSearchLog(searchLog: [SearchKeyword], category: SearchTap) -> [SearchKeyword]
 }
 
 final class FeedSearchInteractor: FeedSearchInteractorProtocol {
@@ -21,6 +22,37 @@ final class FeedSearchInteractor: FeedSearchInteractorProtocol {
   func getSearchLog() {
     self.worker?.getSearchLog { [weak self] log in
       self?.presenter?.presentSearchLog(searchKeyword: log)
+    }
+  }
+
+  func distributeSearchLog(searchLog: [SearchKeyword], category: SearchTap) -> [SearchKeyword] {
+    var tagKeyword: [SearchKeyword] = []
+    var accountKeyword: [SearchKeyword] = []
+    var placeKeyword: [SearchKeyword] = []
+
+    for i in 0..<searchLog.count {
+      let tap = SearchTap(rawValue: searchLog[i].category)
+      switch tap {
+      case .account:
+        accountKeyword.append(searchLog[i])
+      case .tag:
+        tagKeyword.append(searchLog[i])
+      case .place:
+        placeKeyword.append(searchLog[i])
+      default:
+        return []
+      }
+    }
+
+    switch category {
+    case .popular:
+      return searchLog
+    case .account:
+      return accountKeyword
+    case .tag:
+      return tagKeyword
+    case .place:
+      return placeKeyword
     }
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchPresenter.swift
@@ -1,0 +1,17 @@
+//
+//  FeedSearchPresenter.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2022/09/14.
+//
+
+import UIKit
+
+protocol FeedSearchPresenterProtocol {
+  var view: FeedSearchViewProtocol? { get set }
+}
+
+final class FeedSearchPresenter: FeedSearchPresenterProtocol {
+  var view: FeedSearchViewProtocol?
+
+}

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchPresenter.swift
@@ -9,13 +9,13 @@ import UIKit
 
 protocol FeedSearchPresenterProtocol {
   var view: FeedSearchViewProtocol? { get set }
-  func presentSearchLog(searchLog: [SearchLog])
+  func presentSearchLog(searchKeyword: [SearchKeyword])
 }
 
 final class FeedSearchPresenter: FeedSearchPresenterProtocol {
   var view: FeedSearchViewProtocol?
 
-  func presentSearchLog(searchLog: [SearchLog]) {
-    self.view?.fetchSearchLog(searchLog: searchLog)
+  func presentSearchLog(searchKeyword: [SearchKeyword]) {
+    self.view?.fetchSearchLog(searchKeyword: searchKeyword)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchPresenter.swift
@@ -9,9 +9,13 @@ import UIKit
 
 protocol FeedSearchPresenterProtocol {
   var view: FeedSearchViewProtocol? { get set }
+  func presentSearchLog(searchLog: [SearchLog])
 }
 
 final class FeedSearchPresenter: FeedSearchPresenterProtocol {
   var view: FeedSearchViewProtocol?
 
+  func presentSearchLog(searchLog: [SearchLog]) {
+    self.view?.fetchSearchLog(searchLog: searchLog)
+  }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchPresenter.swift
@@ -9,13 +9,13 @@ import UIKit
 
 protocol FeedSearchPresenterProtocol {
   var view: FeedSearchViewProtocol? { get set }
-  func presentSearchLog(searchKeyword: [SearchKeyword])
+  func presentSearchKeywords(searchKeywords: [SearchTap: [SearchKeyword]])
 }
 
 final class FeedSearchPresenter: FeedSearchPresenterProtocol {
   var view: FeedSearchViewProtocol?
 
-  func presentSearchLog(searchKeyword: [SearchKeyword]) {
-    self.view?.fetchSearchLog(searchKeyword: searchKeyword)
+  func presentSearchKeywords(searchKeywords: [SearchTap: [SearchKeyword]]) {
+    self.view?.fetchSearchKeywords(searchKeywords: searchKeywords)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchRouter.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 protocol FeedSearchRouterProtocol {
-  static func createFeedSearch() -> UIViewController
+  static func createFeedSearch(searchLog: [SearchLog]) -> UIViewController
 
 }
 
 final class FeedSearchRouter: FeedSearchRouterProtocol {
-  static func createFeedSearch() -> UIViewController {
+  static func createFeedSearch(searchLog: [SearchLog]) -> UIViewController {
     let view = FeedSearchViewController()
     let interactor = FeedSearchInteractor()
     let presenter = FeedSearchPresenter()
@@ -22,6 +22,7 @@ final class FeedSearchRouter: FeedSearchRouterProtocol {
 
     view.interactor = interactor
     view.router = router
+    view.searchLog = searchLog
     interactor.presenter = presenter
     interactor.worker = worker
     

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchRouter.swift
@@ -1,0 +1,30 @@
+//
+//  FeedSearchRouter.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2022/09/14.
+//
+
+import UIKit
+
+protocol FeedSearchRouterProtocol {
+  static func createFeedSearch() -> UIViewController
+
+}
+
+final class FeedSearchRouter: FeedSearchRouterProtocol {
+  static func createFeedSearch() -> UIViewController {
+    let view = FeedSearchViewController()
+    let interactor = FeedSearchInteractor()
+    let presenter = FeedSearchPresenter()
+    let worker = FeedSearchWorker()
+    let router = FeedSearchRouter()
+
+    view.interactor = interactor
+    view.router = router
+    interactor.presenter = presenter
+    interactor.worker = worker
+    
+    return view
+  }
+}

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchRouter.swift
@@ -9,7 +9,6 @@ import UIKit
 
 protocol FeedSearchRouterProtocol {
   static func createFeedSearch() -> UIViewController
-
 }
 
 final class FeedSearchRouter: FeedSearchRouterProtocol {

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchRouter.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 protocol FeedSearchRouterProtocol {
-  static func createFeedSearch(searchLog: [SearchLog]) -> UIViewController
+  static func createFeedSearch() -> UIViewController
 
 }
 
 final class FeedSearchRouter: FeedSearchRouterProtocol {
-  static func createFeedSearch(searchLog: [SearchLog]) -> UIViewController {
+  static func createFeedSearch() -> UIViewController {
     let view = FeedSearchViewController()
     let interactor = FeedSearchInteractor()
     let presenter = FeedSearchPresenter()
@@ -22,9 +22,9 @@ final class FeedSearchRouter: FeedSearchRouterProtocol {
 
     view.interactor = interactor
     view.router = router
-    view.searchLog = searchLog
     interactor.presenter = presenter
     interactor.worker = worker
+    presenter.view = view
     
     return view
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
@@ -13,7 +13,7 @@ protocol FeedSearchViewProtocol {
   var interactor: FeedSearchInteractorProtocol? { get set }
   var router: FeedSearchRouterProtocol? { get set }
 
-  func fetchSearchLog(searchKeyword: [SearchKeyword])
+  func fetchSearchKeywords(searchKeywords: [SearchTap: [SearchKeyword]])
 }
 
 final class FeedSearchViewController: BaseViewController<FeedSearchView> {
@@ -30,36 +30,16 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
     }
   }
 
-  var searchKeyword: [SearchKeyword] = [] {
-    didSet {
-      self.containerView.searchResultPageCollectionView.reloadData()
-
-      guard let tagKeyword: [SearchKeyword] = self.interactor?.distributeSearchLog(
-        searchLog: searchKeyword,
-        category: SearchTap.tag
-      ) else { return }
-      guard let accountKeyword: [SearchKeyword] = self.interactor?.distributeSearchLog(
-        searchLog: searchKeyword,
-        category: SearchTap.account
-      ) else { return }
-      guard let placeKeyword: [SearchKeyword] = self.interactor?.distributeSearchLog(
-        searchLog: searchKeyword,
-        category: SearchTap.place
-      ) else { return }
-
-      self.keywords.updateValue(searchKeyword, forKey: SearchTap.popular)
-      self.keywords.updateValue(tagKeyword, forKey: SearchTap.tag)
-      self.keywords.updateValue(accountKeyword, forKey: SearchTap.account)
-      self.keywords.updateValue(placeKeyword, forKey: SearchTap.place)
-    }
-  }
-
-  var keywords: [SearchTap: [SearchKeyword]] = [
+  var searchKeywords: [SearchTap: [SearchKeyword]] = [
     SearchTap.popular: [],
     SearchTap.tag: [],
     SearchTap.account: [],
     SearchTap.place: []
-  ]
+  ] {
+    didSet {
+      self.containerView.searchResultPageCollectionView.reloadData()
+    }
+  }
 
   // MARK: - Constants
 
@@ -67,13 +47,13 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
     case tap = 0
     case result = 1
   }
-  
+
   // MARK: - Life Cycles
 
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setupConfigure()
-    self.interactor?.getSearchLog()
+    self.interactor?.getSearchKeywords()
   }
 
   override func setupConfigure() {
@@ -110,8 +90,8 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
 // MARK: - FeedSearchViewProtocol
 
 extension FeedSearchViewController: FeedSearchViewProtocol {
-  func fetchSearchLog(searchKeyword: [SearchKeyword]){
-    self.searchKeyword = searchKeyword
+  func fetchSearchKeywords(searchKeywords: [SearchTap: [SearchKeyword]]){
+    self.searchKeywords = searchKeywords
   }
 }
 
@@ -150,7 +130,7 @@ extension FeedSearchViewController: UICollectionViewDataSource, UICollectionView
         withType: SearchResultPageCell.self,
         for: indexPath
       )
-      cell.bind(index: indexPath, searchKeyword: self.keywords)
+      cell.bind(index: indexPath, searchKeyword: self.searchKeywords)
       
       return cell
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
@@ -28,6 +28,8 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
     }
   }
 
+  var searchLog: [SearchLog] = []
+
   // MARK: - Constants
 
   private enum SearchCollectionViewTag: Int {
@@ -75,6 +77,12 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
       }
     )
   }
+}
+
+  // MARK: - FeedSearchViewProtocol
+
+extension FeedSearchViewController: FeedSearchViewProtocol {
+
 }
 
   // MARK: - CollectionView DataSource, Delegate

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
@@ -9,9 +9,17 @@ import UIKit
 
 import Then
 
+protocol FeedSearchViewProtocol {
+  var interactor: FeedSearchInteractorProtocol? { get set }
+  var router: FeedSearchRouterProtocol? { get set }
+}
+
 final class FeedSearchViewController: BaseViewController<FeedSearchView> {
 
   // MARK: - Properties
+
+  var interactor: FeedSearchInteractorProtocol?
+  var router: FeedSearchRouterProtocol?
 
   private var currentIndex = 0 {
     didSet {

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
@@ -33,8 +33,33 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
   var searchKeyword: [SearchKeyword] = [] {
     didSet {
       self.containerView.searchResultPageCollectionView.reloadData()
+
+      guard let tagKeyword: [SearchKeyword] = self.interactor?.distributeSearchLog(
+        searchLog: searchKeyword,
+        category: SearchTap.tag
+      ) else { return }
+      guard let accountKeyword: [SearchKeyword] = self.interactor?.distributeSearchLog(
+        searchLog: searchKeyword,
+        category: SearchTap.account
+      ) else { return }
+      guard let placeKeyword: [SearchKeyword] = self.interactor?.distributeSearchLog(
+        searchLog: searchKeyword,
+        category: SearchTap.place
+      ) else { return }
+
+      self.keywords.updateValue(searchKeyword, forKey: SearchTap.popular)
+      self.keywords.updateValue(tagKeyword, forKey: SearchTap.tag)
+      self.keywords.updateValue(accountKeyword, forKey: SearchTap.account)
+      self.keywords.updateValue(placeKeyword, forKey: SearchTap.place)
     }
   }
+
+  var keywords: [SearchTap: [SearchKeyword]] = [
+    SearchTap.popular: [],
+    SearchTap.tag: [],
+    SearchTap.account: [],
+    SearchTap.place: []
+  ]
 
   // MARK: - Constants
 
@@ -42,11 +67,7 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
     case tap = 0
     case result = 1
   }
-
-  // MARK: - Properties
-
-  private let taps: [String] = ["인기", "계정", "태그", "장소"]
-
+  
   // MARK: - Life Cycles
 
   override func viewDidLoad() {
@@ -86,7 +107,7 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
   }
 }
 
-  // MARK: - FeedSearchViewProtocol
+// MARK: - FeedSearchViewProtocol
 
 extension FeedSearchViewController: FeedSearchViewProtocol {
   func fetchSearchLog(searchKeyword: [SearchKeyword]){
@@ -94,7 +115,7 @@ extension FeedSearchViewController: FeedSearchViewProtocol {
   }
 }
 
-  // MARK: - CollectionView DataSource, Delegate
+// MARK: - CollectionView DataSource, Delegate
 
 extension FeedSearchViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
   func collectionView(
@@ -118,7 +139,7 @@ extension FeedSearchViewController: UICollectionViewDataSource, UICollectionView
         withType: TapCell.self,
         for: indexPath
       )
-      let isSelected = indexPath.item == self.currentIndex 
+      let isSelected = indexPath.item == self.currentIndex
 
       cell.bind(tapName: SearchTap.allCases[indexPath.item].rawValue, isSelected: isSelected)
 
@@ -129,7 +150,7 @@ extension FeedSearchViewController: UICollectionViewDataSource, UICollectionView
         withType: SearchResultPageCell.self,
         for: indexPath
       )
-      cell.bind(index: indexPath, searchKeyword: self.searchKeyword)
+      cell.bind(index: indexPath, searchKeyword: self.keywords)
       
       return cell
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
@@ -30,7 +30,7 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
     }
   }
 
-  var searchKeywords: [SearchTap: [SearchKeyword]] = [
+  private var searchKeywords: [SearchTap: [SearchKeyword]] = [
     SearchTap.popular: [],
     SearchTap.tag: [],
     SearchTap.account: [],

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
@@ -28,7 +28,7 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
     }
   }
 
-  var searchLog: [SearchLog] = []
+  var searchLog: [SearchLog] = [] 
 
   // MARK: - Constants
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
@@ -12,6 +12,8 @@ import Then
 protocol FeedSearchViewProtocol {
   var interactor: FeedSearchInteractorProtocol? { get set }
   var router: FeedSearchRouterProtocol? { get set }
+
+  func fetchSearchLog(searchLog: [SearchLog])
 }
 
 final class FeedSearchViewController: BaseViewController<FeedSearchView> {
@@ -28,7 +30,11 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
     }
   }
 
-  var searchLog: [SearchLog] = [] 
+  var searchLog: [SearchLog] = [] {
+    didSet {
+      self.containerView.searchResultPageCollectionView.reloadData()
+    }
+  }
 
   // MARK: - Constants
 
@@ -46,6 +52,7 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setupConfigure()
+    self.interactor?.getSearchLog()
   }
 
   override func setupConfigure() {
@@ -82,7 +89,9 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
   // MARK: - FeedSearchViewProtocol
 
 extension FeedSearchViewController: FeedSearchViewProtocol {
-
+  func fetchSearchLog(searchLog: [SearchLog]){
+    self.searchLog = searchLog
+  }
 }
 
   // MARK: - CollectionView DataSource, Delegate
@@ -120,7 +129,7 @@ extension FeedSearchViewController: UICollectionViewDataSource, UICollectionView
         withType: SearchResultPageCell.self,
         for: indexPath
       )
-      cell.bind(index: indexPath)
+      cell.bind(index: indexPath, searchLog: self.searchLog)
       
       return cell
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchViewController.swift
@@ -13,7 +13,7 @@ protocol FeedSearchViewProtocol {
   var interactor: FeedSearchInteractorProtocol? { get set }
   var router: FeedSearchRouterProtocol? { get set }
 
-  func fetchSearchLog(searchLog: [SearchLog])
+  func fetchSearchLog(searchKeyword: [SearchKeyword])
 }
 
 final class FeedSearchViewController: BaseViewController<FeedSearchView> {
@@ -30,7 +30,7 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
     }
   }
 
-  var searchLog: [SearchLog] = [] {
+  var searchKeyword: [SearchKeyword] = [] {
     didSet {
       self.containerView.searchResultPageCollectionView.reloadData()
     }
@@ -89,8 +89,8 @@ final class FeedSearchViewController: BaseViewController<FeedSearchView> {
   // MARK: - FeedSearchViewProtocol
 
 extension FeedSearchViewController: FeedSearchViewProtocol {
-  func fetchSearchLog(searchLog: [SearchLog]){
-    self.searchLog = searchLog
+  func fetchSearchLog(searchKeyword: [SearchKeyword]){
+    self.searchKeyword = searchKeyword
   }
 }
 
@@ -129,7 +129,7 @@ extension FeedSearchViewController: UICollectionViewDataSource, UICollectionView
         withType: SearchResultPageCell.self,
         for: indexPath
       )
-      cell.bind(index: indexPath, searchLog: self.searchLog)
+      cell.bind(index: indexPath, searchKeyword: self.searchKeyword)
       
       return cell
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
@@ -8,9 +8,23 @@
 import UIKit
 
 protocol FeedSearchWorkerProtocol {
-
+  func getSearchLog(completionHandler: @escaping ([SearchLog]) -> Void)
 }
 
 final class FeedSearchWorker: FeedSearchWorkerProtocol {
+  private let userDefaults = UserDefaults.standard
+  
+  func getSearchLog(completionHandler: @escaping ([SearchLog]) -> Void) {
+    var searchLog: [SearchLog] = []
 
+    guard let log = userDefaults.object(forKey: "searchLog") as? [[String: Any]] else { return }
+
+    searchLog = log.compactMap {
+      guard let regDate = $0["regDate"] as? Date else { return nil }
+      guard let keyword = $0["keyword"] as? String else { return nil }
+      guard let category = $0["category"] as? String else { return nil }
+      return SearchLog(regDate: regDate, category: category, keyword: keyword)
+    }
+    completionHandler(searchLog)
+  }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
@@ -20,9 +20,9 @@ final class FeedSearchWorker: FeedSearchWorkerProtocol {
     guard let log = userDefaults.object(forKey: "searchLog") as? [[String: Any]] else { return }
 
     searchKeyword = log.compactMap {
-//      guard let regDate = $0["regDate"] as? Date else { return nil }
       guard let keyword = $0["keyword"] as? String else { return nil }
       guard let category = $0["category"] as? String else { return nil }
+      
       return SearchKeyword(category: category, keyword: keyword)
     }
     completionHandler(searchKeyword)

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
@@ -1,0 +1,16 @@
+//
+//  FeedSearchWorker.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2022/09/14.
+//
+
+import UIKit
+
+protocol FeedSearchWorkerProtocol {
+
+}
+
+final class FeedSearchWorker: FeedSearchWorkerProtocol {
+
+}

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
@@ -8,23 +8,23 @@
 import UIKit
 
 protocol FeedSearchWorkerProtocol {
-  func getSearchLog(completionHandler: @escaping ([SearchLog]) -> Void)
+  func getSearchLog(completionHandler: @escaping ([SearchKeyword]) -> Void)
 }
 
 final class FeedSearchWorker: FeedSearchWorkerProtocol {
   private let userDefaults = UserDefaults.standard
   
-  func getSearchLog(completionHandler: @escaping ([SearchLog]) -> Void) {
-    var searchLog: [SearchLog] = []
+  func getSearchLog(completionHandler: @escaping ([SearchKeyword]) -> Void) {
+    var searchKeyword: [SearchKeyword] = []
 
     guard let log = userDefaults.object(forKey: "searchLog") as? [[String: Any]] else { return }
 
-    searchLog = log.compactMap {
-      guard let regDate = $0["regDate"] as? Date else { return nil }
+    searchKeyword = log.compactMap {
+//      guard let regDate = $0["regDate"] as? Date else { return nil }
       guard let keyword = $0["keyword"] as? String else { return nil }
       guard let category = $0["category"] as? String else { return nil }
-      return SearchLog(regDate: regDate, category: category, keyword: keyword)
+      return SearchKeyword(category: category, keyword: keyword)
     }
-    completionHandler(searchLog)
+    completionHandler(searchKeyword)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/FeedSearchWorker.swift
@@ -8,23 +8,23 @@
 import UIKit
 
 protocol FeedSearchWorkerProtocol {
-  func getSearchLog(completionHandler: @escaping ([SearchKeyword]) -> Void)
+  func getSearchKeywords(completionHandler: @escaping ([SearchKeyword]) -> Void)
 }
 
 final class FeedSearchWorker: FeedSearchWorkerProtocol {
   private let userDefaults = UserDefaults.standard
   
-  func getSearchLog(completionHandler: @escaping ([SearchKeyword]) -> Void) {
-    var searchKeyword: [SearchKeyword] = []
+  func getSearchKeywords(completionHandler: @escaping ([SearchKeyword]) -> Void) {
+    var searchKeywords: [SearchKeyword] = []
 
     guard let log = userDefaults.object(forKey: "searchLog") as? [[String: Any]] else { return }
 
-    searchKeyword = log.compactMap {
+    searchKeywords = log.compactMap {
       guard let keyword = $0["keyword"] as? String else { return nil }
       guard let category = $0["category"] as? String else { return nil }
       
       return SearchKeyword(category: category, keyword: keyword)
     }
-    completionHandler(searchKeyword)
+    completionHandler(searchKeywords)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedSearch/Views/FeedSearchResultHeaderReusableView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedSearch/Views/FeedSearchResultHeaderReusableView.swift
@@ -43,6 +43,17 @@ final class FeedSearchResultHeaderReusableView: UICollectionReusableView {
     fatalError("init(coder:) has not been implemented")
   }
 
+  // MARK: - Bind
+
+  func bind(isEmpty: Bool) {
+    self.deleteLogButton.isHidden = isEmpty
+    if isEmpty {
+      self.headerLabel.text = "최근 검색기록이 없습니다."
+    } else {
+      self.headerLabel.text = "최근 검색"
+    }
+  }
+
   // MARK: - Configure
 
   private func setupConstraints() {


### PR DESCRIPTION
## What is this PR?
- 검색한 키워드를 저장하고 불러오는 기능을 작성하였습니다.
- 인기 상위 3개 키워드는 해당 pr에서 제외됩니다.

## Changes
- `UserDefaults`를 사용하여 검색 키워드를 저장합니다.
- 기능 구현 위치
  - 저장 -> `FeedMain`
  - 불러오기 -> `FeedSearch`

## Test Checklist
- 키보드 외 화면을 터치해도 키보드 숨김 처리가 작동하지 않는 이슈가 있습니다.
- 키워드를 계정/태그/장소로 구분하는 방식에 대한 논의가 필요합니다.