### PR TITLE
[FEAT] 피드 작성 present 방식 적용

### DIFF
--- a/KnockKnock-iOS.xcodeproj/project.pbxproj
+++ b/KnockKnock-iOS.xcodeproj/project.pbxproj
@@ -131,7 +131,6 @@
 		61A02840290A4FD000943A40 /* DistrictsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A0283F290A4FD000943A40 /* DistrictsType.swift */; };
 		61A02843290E347900943A40 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 61A02842290E347900943A40 /* Lottie */; };
 		61A02846290E358F00943A40 /* zero_waste_loading.json in Resources */ = {isa = PBXBuildFile; fileRef = 61A02845290E358F00943A40 /* zero_waste_loading.json */; };
-
 		61A02848290F5F5E00943A40 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A02847290F5F5E00943A40 /* NoticeView.swift */; };
 		61A0284A290F5F6B00943A40 /* NoticeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A02849290F5F6B00943A40 /* NoticeViewController.swift */; };
 		61A0284C290F5F7D00943A40 /* NoticeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A0284B290F5F7D00943A40 /* NoticeRouter.swift */; };
@@ -146,12 +145,10 @@
 		61A028612912242100943A40 /* NoticeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A028602912242100943A40 /* NoticeDetailView.swift */; };
 		61A028632912279500943A40 /* NoticeDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A028622912279500943A40 /* NoticeDetailViewController.swift */; };
 		61A0286B2912456500943A40 /* MyRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A0286A2912456500943A40 /* MyRouter.swift */; };
-
 		61A0286F29139D6400943A40 /* ProfileSettingRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A0286E29139D6400943A40 /* ProfileSettingRouter.swift */; };
 		61A028712913A31600943A40 /* ProfileSettingInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A028702913A31600943A40 /* ProfileSettingInteractor.swift */; };
 		61A028732913A32900943A40 /* ProfileSettingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A028722913A32900943A40 /* ProfileSettingPresenter.swift */; };
 		61A028752913A33200943A40 /* ProfileSettingWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A028742913A33200943A40 /* ProfileSettingWorker.swift */; };
-
 		61A028772913AC5200943A40 /* Promotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A028762913AC5200943A40 /* Promotion.swift */; };
 		61A0287D2914DDD700943A40 /* PropertySelectInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A0287C2914DDD700943A40 /* PropertySelectInteractor.swift */; };
 		61A0287F2914DDF500943A40 /* PropertySelectPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A0287E2914DDF500943A40 /* PropertySelectPresenter.swift */; };
@@ -176,20 +173,16 @@
 		61AB2E5928A620B700A1AE30 /* EventPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AB2E5828A620B700A1AE30 /* EventPageView.swift */; };
 		61AB2E5B28A620C700A1AE30 /* EventPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AB2E5A28A620C700A1AE30 /* EventPageViewController.swift */; };
 		61AB2E5D28A6257E00A1AE30 /* TapCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AB2E5C28A6257E00A1AE30 /* TapCell.swift */; };
-
-		61B20B6B2928EF4400EBA596 /* ImagePickerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B6A2928EF4400EBA596 /* ImagePickerManager.swift */; };
-
 		61B20B51292398C700EBA596 /* KKRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B50292398C700EBA596 /* KKRequestInterceptor.swift */; };
 		61B20B572924BD7800EBA596 /* LocalDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B562924BD7800EBA596 /* LocalDataManager.swift */; };
 		61B20B592925FFA600EBA596 /* UIWindow+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B582925FFA600EBA596 /* UIWindow+Ext.swift */; };
-
 		61B20B5B29261B3B00EBA596 /* My.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B5A29261B3B00EBA596 /* My.swift */; };
 		61B20B5D29261B9600EBA596 /* MyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B5C29261B9600EBA596 /* MyType.swift */; };
 		61B20B632926409800EBA596 /* MyTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B622926409800EBA596 /* MyTableViewHeader.swift */; };
 		61B20B652927323E00EBA596 /* MyTableViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B642927323E00EBA596 /* MyTableViewFooter.swift */; };
 		61B20B672927393000EBA596 /* BaseTableViewHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B662927393000EBA596 /* BaseTableViewHeaderFooterView.swift */; };
 		61B20B6929273CAF00EBA596 /* UITableHeaderFooterView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B6829273CAF00EBA596 /* UITableHeaderFooterView+Ext.swift */; };
-
+		61B20B6B2928EF4400EBA596 /* ImagePickerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B20B6A2928EF4400EBA596 /* ImagePickerManager.swift */; };
 		61B6D97F2888FA6800E60F08 /* ChallengeDetailHeaderCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B6D97E2888FA6800E60F08 /* ChallengeDetailHeaderCollectionReusableView.swift */; };
 		61B6D984288A967A00E60F08 /* ChallengeDetailWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B6D983288A967A00E60F08 /* ChallengeDetailWorker.swift */; };
 		61B6D986288A968600E60F08 /* ChallengeDetailInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B6D985288A968600E60F08 /* ChallengeDetailInteractor.swift */; };
@@ -352,7 +345,6 @@
 		61A0283C29090B4500943A40 /* BottomSheetRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetRouter.swift; sourceTree = "<group>"; };
 		61A0283F290A4FD000943A40 /* DistrictsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistrictsType.swift; sourceTree = "<group>"; };
 		61A02845290E358F00943A40 /* zero_waste_loading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = zero_waste_loading.json; sourceTree = "<group>"; };
-
 		61A02847290F5F5E00943A40 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		61A02849290F5F6B00943A40 /* NoticeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewController.swift; sourceTree = "<group>"; };
 		61A0284B290F5F7D00943A40 /* NoticeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeRouter.swift; sourceTree = "<group>"; };
@@ -367,12 +359,10 @@
 		61A028602912242100943A40 /* NoticeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailView.swift; sourceTree = "<group>"; };
 		61A028622912279500943A40 /* NoticeDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailViewController.swift; sourceTree = "<group>"; };
 		61A0286A2912456500943A40 /* MyRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRouter.swift; sourceTree = "<group>"; };
-
 		61A0286E29139D6400943A40 /* ProfileSettingRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingRouter.swift; sourceTree = "<group>"; };
 		61A028702913A31600943A40 /* ProfileSettingInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingInteractor.swift; sourceTree = "<group>"; };
 		61A028722913A32900943A40 /* ProfileSettingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingPresenter.swift; sourceTree = "<group>"; };
 		61A028742913A33200943A40 /* ProfileSettingWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingWorker.swift; sourceTree = "<group>"; };
-
 		61A028762913AC5200943A40 /* Promotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Promotion.swift; sourceTree = "<group>"; };
 		61A0287C2914DDD700943A40 /* PropertySelectInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertySelectInteractor.swift; sourceTree = "<group>"; };
 		61A0287E2914DDF500943A40 /* PropertySelectPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertySelectPresenter.swift; sourceTree = "<group>"; };
@@ -397,9 +387,6 @@
 		61AB2E5828A620B700A1AE30 /* EventPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPageView.swift; sourceTree = "<group>"; };
 		61AB2E5A28A620C700A1AE30 /* EventPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPageViewController.swift; sourceTree = "<group>"; };
 		61AB2E5C28A6257E00A1AE30 /* TapCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapCell.swift; sourceTree = "<group>"; };
-
-		61B20B6A2928EF4400EBA596 /* ImagePickerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerManager.swift; sourceTree = "<group>"; };
-
 		61B20B50292398C700EBA596 /* KKRequestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KKRequestInterceptor.swift; sourceTree = "<group>"; };
 		61B20B562924BD7800EBA596 /* LocalDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataManager.swift; sourceTree = "<group>"; };
 		61B20B582925FFA600EBA596 /* UIWindow+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+Ext.swift"; sourceTree = "<group>"; };
@@ -409,7 +396,7 @@
 		61B20B642927323E00EBA596 /* MyTableViewFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTableViewFooter.swift; sourceTree = "<group>"; };
 		61B20B662927393000EBA596 /* BaseTableViewHeaderFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewHeaderFooterView.swift; sourceTree = "<group>"; };
 		61B20B6829273CAF00EBA596 /* UITableHeaderFooterView+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableHeaderFooterView+Ext.swift"; sourceTree = "<group>"; };
-
+		61B20B6A2928EF4400EBA596 /* ImagePickerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerManager.swift; sourceTree = "<group>"; };
 		61B6D97E2888FA6800E60F08 /* ChallengeDetailHeaderCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeDetailHeaderCollectionReusableView.swift; sourceTree = "<group>"; };
 		61B6D983288A967A00E60F08 /* ChallengeDetailWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeDetailWorker.swift; sourceTree = "<group>"; };
 		61B6D985288A968600E60F08 /* ChallengeDetailInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeDetailInteractor.swift; sourceTree = "<group>"; };
@@ -824,13 +811,11 @@
 			isa = PBXGroup;
 			children = (
 				61A02845290E358F00943A40 /* zero_waste_loading.json */,
-
 				61B20B6A2928EF4400EBA596 /* ImagePickerManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
 		};
-
 		61A0284F290F60C700943A40 /* My */ = {
 			isa = PBXGroup;
 			children = (
@@ -859,7 +844,6 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
-
 		61A0286C29139C7B00943A40 /* ProfileSetting */ = {
 			isa = PBXGroup;
 			children = (
@@ -881,7 +865,6 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
-
 		61A0287A2914DD8500943A40 /* Property */ = {
 			isa = PBXGroup;
 			children = (
@@ -1450,13 +1433,9 @@
 				61AB2E5B28A620C700A1AE30 /* EventPageViewController.swift in Sources */,
 				61B20B632926409800EBA596 /* MyTableViewHeader.swift in Sources */,
 				6139004528E5605900CC9950 /* UINavigationBar+Ext.swift in Sources */,
-
-				61A730DF28ED4EBA00C6BD98 /* SettingViewController.swift in Sources */,
-
 				61A730DF28ED4EBA00C6BD98 /* MyViewController.swift in Sources */,
-				61A8DC5D288685BE000512EC /* ReplyCell.swift in Sources */,
+				61A730DF28ED4EBA00C6BD98 /* MyViewController.swift in Sources */,
 				61B20B672927393000EBA596 /* BaseTableViewHeaderFooterView.swift in Sources */,
-
 				618FDAC727E82A6F00C2823F /* AddressCell.swift in Sources */,
 				61A028512910D3A700943A40 /* LoginInteractor.swift in Sources */,
 				6143297C28687B7F008BDCC9 /* FeedListRouter.swift in Sources */,

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWritePresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWritePresenter.swift
@@ -10,29 +10,49 @@ import Foundation
 protocol FeedWritePresenterProtocol: AnyObject {
   var view: FeedWriteViewProtocol? { get set }
 
-  func fetchProperty(propertyType: PropertyType, content: String)
-
   func presentSelectedPromotions(promotionList: [Promotion])
   func presentSelectedTags(tagList: [ChallengeTitle])
+  func presentShopAddress(address: String)
 }
 
 final class FeedWritePresenter: FeedWritePresenterProtocol {
   weak var view: FeedWriteViewProtocol?
 
-  func presentSelectedPromotions(promotionList: [Promotion]) {
-    self.view?.fetchSelectedPromotions(promotionList: promotionList)
-  }
-  
-  func presentSelectedTags(tagList: [ChallengeTitle]) {
-    self.view?.fetchSelectedTags(tagList: tagList)
+  func presentShopAddress(address: String) {
+    self.view?.fetchProperty(
+      propertyType: .address,
+      content: address
+    )
   }
 
-  func fetchProperty(
-    propertyType: PropertyType,
-    content: String
-  ) {
+  func presentSelectedPromotions(promotionList: [Promotion]) {
+    let selection = promotionList.filter { $0.isSelected == true }
+
+    var content = selection.map {
+      $0.promotionInfo.type
+    }.joined(separator: ", ")
+
+    if selection.isEmpty {
+      content = "프로모션"
+    }
     self.view?.fetchProperty(
-      propertyType: propertyType,
+      propertyType: .promotion,
+      content: content
+    )
+  }
+
+  func presentSelectedTags(tagList: [ChallengeTitle]) {
+    let selection = tagList.filter { $0.isSelected == true }
+
+    var content = selection.map {
+      $0.title
+    }.joined(separator: ", ")
+
+    if selection.isEmpty {
+      content = "#태그"
+    }
+    self.view?.fetchProperty(
+      propertyType: .tag,
       content: content
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteRouter.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol FeedWriteRouterProtocol: AnyObject {
   static func createFeedWrite() -> UIViewController
 
+  func dismissFeedWriteView(source: FeedWriteViewProtocol)
   func navigateToShopSearch(source: FeedWriteViewProtocol)
   func navigateToProperty(
     source: FeedWriteViewProtocol,
@@ -69,6 +70,12 @@ final class FeedWriteRouter: FeedWriteRouterProtocol {
       if let sourceView = source as? UIViewController {
         sourceView.navigationController?.pushViewController(propertyViewController, animated: true)
       }
+    }
+  }
+
+  func dismissFeedWriteView(source: FeedWriteViewProtocol) {
+    if let sourceView = source as? UIViewController {
+      sourceView.dismiss(animated: true)
     }
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteRouter.swift
@@ -33,7 +33,7 @@ final class FeedWriteRouter: FeedWriteRouterProtocol {
     let router = FeedWriteRouter()
 
     view.interactor = interactor
-    view.router = router
+    interactor.router = router
     interactor.presenter = presenter
     interactor.worker = worker
     presenter.view = view

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
@@ -13,12 +13,8 @@ import KKDSKit
 
 protocol FeedWriteViewProtocol: AnyObject {
   var interactor: FeedWriteInteractorProtocol? { get set }
-  var router: FeedWriteRouterProtocol? { get set }
 
   func fetchProperty(propertyType: PropertyType, content: String)
-
-  func fetchSelectedPromotions(promotionList: [Promotion])
-  func fetchSelectedTags(tagList: [ChallengeTitle])
 }
 
 final class FeedWriteViewController: BaseViewController<FeedWriteView> {
@@ -26,10 +22,6 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
   // MARK: - Properties
   
   var interactor: FeedWriteInteractorProtocol?
-  var router: FeedWriteRouterProtocol?
-
-  private var selectedPromotion: [Promotion] = []
-  private var selectedTag: [ChallengeTitle] = []
 
   var pickedPhotos: [UIImage] = []
 
@@ -95,29 +87,25 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
   // MARK: - Button Actions
 
   @objc func tagSelectButtonDidTap(_ sender: UIButton) {
-    self.router?.navigateToProperty(
+    self.interactor?.navigateToProperty(
       source: self,
-      propertyType: .tag,
-      promotionList: nil,
-      tagList: self.selectedTag
+      propertyType: .tag
     )
   }
 
   @objc func promotionSelectButtonDidTap(_ sender: UIButton) {
-    self.router?.navigateToProperty(
+    self.interactor?.navigateToProperty(
       source: self,
-      propertyType: .promotion,
-      promotionList: self.selectedPromotion,
-      tagList: nil
+      propertyType: .promotion
     )
   }
 
   @objc func dismissBarButtonDidTap(_ sender: UIBarButtonItem) {
-    self.dismiss(animated: true)
+    self.interactor?.dismissFeedWriteView(source: self)
   }
 
   @objc func shopSearchButtonDidTap(_ sender: UIButton) {
-    self.router?.navigateToShopSearch(source: self)
+    self.interactor?.navigateToShopSearch(source: self)
   }
 
   @objc func photoAddButtonDidTap(_ sender: UIButton) {
@@ -164,16 +152,9 @@ extension FeedWriteViewController: FeedWriteViewProtocol {
       content: content
     )
   }
-  func fetchSelectedPromotions(promotionList: [Promotion]){
-    self.selectedPromotion = promotionList
-  }
-
-  func fetchSelectedTags(tagList: [ChallengeTitle]){
-    self.selectedTag = tagList
-  }
 }
 
-  // MARK: - TextView Delegate
+// MARK: - TextView Delegate
 
 extension FeedWriteViewController: UITextViewDelegate {
   func textViewDidBeginEditing(_ textView: UITextView) {
@@ -191,7 +172,7 @@ extension FeedWriteViewController: UITextViewDelegate {
   }
 }
 
-  // MARK: - CollectionView DataSource
+// MARK: - CollectionView DataSource
 
 extension FeedWriteViewController: UICollectionViewDataSource {
   func collectionView(
@@ -224,7 +205,7 @@ extension FeedWriteViewController: UICollectionViewDataSource {
   }
 }
 
-  // MARK: - CollectionView Delegate
+// MARK: - CollectionView Delegate
 
 extension FeedWriteViewController: UICollectionViewDelegateFlowLayout {
   func collectionView(
@@ -234,7 +215,7 @@ extension FeedWriteViewController: UICollectionViewDelegateFlowLayout {
   ) -> CGSize {
     return CGSize(
       width: self.containerView.photoAddButton.frame.width + 10,
-                  height: self.containerView.photoAddButton.frame.height + 10
+      height: self.containerView.photoAddButton.frame.height + 10
     )
   }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
@@ -33,6 +33,17 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
 
   var pickedPhotos: [UIImage] = []
 
+  // MARK: - UIs
+
+  private lazy var dismissBarButtonItem = UIBarButtonItem(
+    image: KKDS.Image.ic_close_24_bk,
+    style: .plain,
+    target: self,
+    action: #selector(self.dismissBarButtonDidTap(_:))
+  ).then {
+    $0.tintColor = .black
+  }
+
   // MARK: - Life cycle
 
   override func viewDidLoad() {
@@ -43,7 +54,11 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
 
   override func setupConfigure() {
     self.hideKeyboardWhenTappedAround()
-    self.navigationItem.title = "새 게시글"
+
+    self.navigationItem.do {
+      $0.title = "새 게시글"
+      $0.leftBarButtonItem = self.dismissBarButtonItem
+    }
     self.navigationController?.navigationBar.setDefaultAppearance()
 
     self.containerView.photoCollectionView.do {
@@ -95,6 +110,10 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
       promotionList: self.selectedPromotion,
       tagList: nil
     )
+  }
+
+  @objc func dismissBarButtonDidTap(_ sender: UIBarButtonItem) {
+    self.dismiss(animated: true)
   }
 
   @objc func shopSearchButtonDidTap(_ sender: UIButton) {

--- a/KnockKnock-iOS/Scenes/MainTabBarController.swift
+++ b/KnockKnock-iOS/Scenes/MainTabBarController.swift
@@ -60,14 +60,9 @@ final class MainTabBarController: UITabBarController {
   let challenge = ChallengeRouter.createChallenge()
   let my = MyRouter.createMy()
 
-  lazy var middleButton = UIButton().then {
+  let postButton = UIButton().then {
     $0.frame.size = CGSize(width: 40, height: 40)
     $0.setImage(KKDS.Image.ic_bottom_more_40, for: .normal)
-    $0.addTarget(
-      self,
-      action: #selector(self.middleButtonDidTap),
-      for: .touchUpInside
-    )
   }
 
   // MARK: - Initialize
@@ -119,7 +114,7 @@ final class MainTabBarController: UITabBarController {
     ]
   }
 
-  @objc func middleButtonDidTap(_ sender: UIButton) {
+  @objc func postButtonDidTap(_ sender: UIButton) {
     let postNVC = UINavigationController(rootViewController: self.post)
     postNVC.modalPresentationStyle = .fullScreen
 
@@ -127,15 +122,15 @@ final class MainTabBarController: UITabBarController {
   }
 
   private func setMiddleButton() {
-    self.tabBar.addSubview(middleButton)
-    self.middleButton.snp.makeConstraints {
+    self.tabBar.addSubview(postButton)
+    self.postButton.snp.makeConstraints {
       $0.centerX.equalToSuperview()
       $0.centerY.equalToSuperview().offset(-15)
     }
 
-    self.middleButton.addTarget(
+    self.postButton.addTarget(
       self,
-      action: #selector(self.middleButtonDidTap(_:)),
+      action: #selector(self.postButtonDidTap(_:)),
       for: .touchUpInside
     )
   }

--- a/KnockKnock-iOS/Scenes/MainTabBarController.swift
+++ b/KnockKnock-iOS/Scenes/MainTabBarController.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+
+import SnapKit
 import KKDSKit
 
 import Then
@@ -37,8 +39,8 @@ final class MainTabBarController: UITabBarController {
     ),
     .post: UITabBarItem(
       title: nil,
-      image: KKDS.Image.ic_bottom_more_40.withRenderingMode(.alwaysOriginal),
-      selectedImage: KKDS.Image.ic_bottom_more_40.withRenderingMode(.alwaysOriginal)
+      image: nil,
+      selectedImage: nil
     ),
     .challenge: UITabBarItem(
       title: "챌린지",
@@ -56,8 +58,17 @@ final class MainTabBarController: UITabBarController {
   let feed = FeedMainRouter.createFeed()
   let post = FeedWriteRouter.createFeedWrite()
   let challenge = ChallengeRouter.createChallenge()
-//  let my = LoginRouter.createLoginView()
   let my = MyRouter.createMy()
+
+  lazy var middleButton = UIButton().then {
+    $0.frame.size = CGSize(width: 40, height: 40)
+    $0.setImage(KKDS.Image.ic_bottom_more_40, for: .normal)
+    $0.addTarget(
+      self,
+      action: #selector(self.middleButtonDidTap),
+      for: .touchUpInside
+    )
+  }
 
   // MARK: - Initialize
   
@@ -74,6 +85,7 @@ final class MainTabBarController: UITabBarController {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.attribute()
+    self.setMiddleButton()
   }
   
   private func attribute() {
@@ -90,26 +102,55 @@ final class MainTabBarController: UITabBarController {
     self.home.tabBarItem = self.tabBarItems[.home]
     self.feed.tabBarItem = self.tabBarItems[.feed]
     self.post.tabBarItem = self.tabBarItems[.post]
-    self.post.tabBarItem.imageInsets = UIEdgeInsets(top: 6, left: 0, bottom: -8, right: 0)
     self.challenge.tabBarItem = self.tabBarItems[.challenge]
     self.my.tabBarItem = self.tabBarItems[.my]
     
     let homeNVC = UINavigationController(rootViewController: self.home)
     let feedNVC = UINavigationController(rootViewController: self.feed)
-    let postNVC = UINavigationController(rootViewController: self.post)
     let challengeNVC = UINavigationController(rootViewController: self.challenge)
     let myNVC = UINavigationController(rootViewController: self.my)
     
     self.viewControllers = [
       homeNVC,
       feedNVC,
-      postNVC,
+      UIViewController(),
       challengeNVC,
       myNVC
     ]
   }
+
+  @objc func middleButtonDidTap(_ sender: UIButton) {
+    let postNVC = UINavigationController(rootViewController: self.post)
+    postNVC.modalPresentationStyle = .fullScreen
+
+    self.present(postNVC, animated: true)
+  }
+
+  private func setMiddleButton() {
+    self.tabBar.addSubview(middleButton)
+    self.middleButton.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.centerY.equalToSuperview().offset(-15)
+    }
+
+    self.middleButton.addTarget(
+      self,
+      action: #selector(self.middleButtonDidTap(_:)),
+      for: .touchUpInside
+    )
+  }
 }
 
 extension MainTabBarController: UITabBarControllerDelegate {
-  
+  func tabBarController(
+    _ tabBarController: UITabBarController,
+    shouldSelect viewController: UIViewController
+  ) -> Bool {
+    if let selectedIndex = tabBarController.viewControllers?.firstIndex(of: viewController) {
+      if Tab(rawValue: selectedIndex) == .post {
+        return false
+      }
+    }
+    return true
+  }
 }

--- a/KnockKnock-iOS/Scenes/MainTabBarController.swift
+++ b/KnockKnock-iOS/Scenes/MainTabBarController.swift
@@ -85,6 +85,7 @@ final class MainTabBarController: UITabBarController {
   
   private func attribute() {
     self.delegate = self
+
     self.tabBar.do {
       $0.backgroundColor = .white
       $0.tintColor = .green50


### PR DESCRIPTION
## What is this PR?
- 탭바의 버튼을 추가하여 피드 작성 화면이 present 되도록 변경하였습니다.
- 피드 작성 관련 라우팅 로직을 interactor에서 담당하도록 하고, 선택된 프로퍼티(태그, 챌린지)를 interactor에서 관리하도록 리팩토링하였습니다.

## Changes
- `mainTabBarController`의 post tabItem을 비활성화 하고, 그 자리에 버튼을 추가하여 피드 작성 화면을 호출합니다.

## Test Checklist
- iOS14 환경에서 피드 작성 화면을 껏다가 다시 키면(present -> dismiss -> present)  navigationBarApperance 적용이 해제되는 이슈가 있습니다.

https://user-images.githubusercontent.com/40792935/204493454-3f966e95-d837-4747-a85b-51a43bbefc4a.mp4

