### PR TITLE
[FEAT] 좋아요 목록 조회 

### DIFF
--- a/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk",
       "state" : {
-        "revision" : "8b968cfd71e3612dd43892910f8f8b8ca69cd51b",
-        "version" : "2.11.3"
+        "revision" : "8a68442660d411031888e6e42c4f628933f62401",
+        "version" : "2.11.1"
       }
     },
     {

--- a/KnockKnock-iOS/Entity/Like.swift
+++ b/KnockKnock-iOS/Entity/Like.swift
@@ -7,8 +7,18 @@
 
 import Foundation
 
-struct Like: Decodable {
+struct LikeResponse: Decodable {
+  let data: LikeData
+}
+
+struct LikeData: Decodable {
+  let postId: String
+  let likes: [LikeInfo]
+}
+
+struct LikeInfo: Decodable {
+  let id: Int
   let userId: Int
-  let nickname: String
-  let image: String?
+  let userName: String
+  let userImage: String?
 }

--- a/KnockKnock-iOS/Network/KKRouter.swift
+++ b/KnockKnock-iOS/Network/KKRouter.swift
@@ -38,6 +38,8 @@ enum KKRouter: URLRequestConvertible {
   case getComment(id: Int)
   case postAddComment(comment: Parameters)
 
+  case getLikeList(id: Int)
+
   var method: HTTPMethod {
     switch self {
     case .getChallengeResponse,
@@ -48,6 +50,7 @@ enum KKRouter: URLRequestConvertible {
         .getPromotions,
         .getChallengeDetail,
         .requestShopAddress,
+        .getLikeList,
         .getComment:
       return .get
 
@@ -73,6 +76,7 @@ enum KKRouter: URLRequestConvertible {
     case .getFeed(let id): return "feed/\(id)"
     case .getComment(let id): return "feed/\(id)/comment"
     case .postAddComment: return "feed/comment"
+    case .getLikeList(let id): return "like/feed/\(id)"
     }
   }
 
@@ -85,11 +89,12 @@ enum KKRouter: URLRequestConvertible {
     case let .signUp(userInfo):
       return userInfo
 
-    case  .getChallengeDetail,
+    case .getChallengeDetail,
         .getChallengeResponse,
         .getChallengeTitles,
         .getFeed,
         .getPromotions,
+        .getLikeList,
         .getComment:
 
       return nil
@@ -128,7 +133,7 @@ enum KKRouter: URLRequestConvertible {
     case .get:
       switch self {
 
-      case .getChallengeDetail, .getFeed, .getPromotions, .getComment:
+      case .getChallengeDetail, .getFeed, .getPromotions, .getComment, .getLikeList:
         break
 
       case .requestShopAddress:

--- a/KnockKnock-iOS/Repository/LikeRepository.swift
+++ b/KnockKnock-iOS/Repository/LikeRepository.swift
@@ -8,21 +8,22 @@
 import Foundation
 
 protocol LikeRepositoryProtocol {
-  func getlike(completionHandler: @escaping ([Like]) -> Void)
+  func getLikeList(feedId: Int, completionHandler: @escaping ([LikeInfo]) -> Void)
 }
 
 final class LikeRepository: LikeRepositoryProtocol {
-  func getlike(completionHandler: @escaping ([Like]) -> Void) {
-    let like = [
-      Like(userId: 2, nickname: "ksungmin94", image: nil),
-      Like(userId: 2, nickname: "jerrychoi", image: nil),
-      Like(userId: 2, nickname: "jjong", image: nil),
-      Like(userId: 2, nickname: "borry", image: nil),
-      Like(userId: 2, nickname: "sangwon", image: nil),
-      Like(userId: 2, nickname: "honggyu", image: nil),
-      Like(userId: 2, nickname: "daye", image: nil),
-      Like(userId: 2, nickname: "username", image: nil)
-    ]
-    completionHandler(like)
+  func getLikeList(feedId: Int, completionHandler: @escaping ([LikeInfo]) -> Void) {
+    KKNetworkManager
+      .shared
+      .request(
+        object: LikeResponse.self,
+        router: KKRouter.getLikeList(id: feedId),
+        success: { response in
+          completionHandler(response.data.likes)
+        },
+        failure: { error in
+          print(error)
+        }
+      )
   }
 }

--- a/KnockKnock-iOS/Scenes/Cells/LikeCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/LikeCell.swift
@@ -64,6 +64,8 @@ final class LikeCell: BaseCollectionViewCell {
     NSLayoutConstraint.activate([
       self.profileImageView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
       self.profileImageView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+      self.profileImageView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
+      self.profileImageView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
       self.profileImageView.heightAnchor.constraint(equalToConstant: Metric.profileImageViewHeight),
       self.profileImageView.widthAnchor.constraint(equalToConstant: Metric.profileImageViewWidth),
       

--- a/KnockKnock-iOS/Scenes/Cells/LikeDetailCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/LikeDetailCell.swift
@@ -51,13 +51,13 @@ final class LikeDetailCell: BaseCollectionViewCell {
 
   // MARK: - Bind
 
-  func bind(like: Like) {
-    if let image = like.image {
+  func bind(like: LikeInfo) {
+    if let image = like.userImage {
       self.profileImageView.image = UIImage(named: image)
     } else {
       self.profileImageView.image = KKDS.Image.ic_person_24
     }
-      self.userNameLabel.text = like.nickname
+      self.userNameLabel.text = like.userName
   }
 
   // MARK: - Constraints

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -26,7 +26,7 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
   var presenter: FeedDetailPresenterProtocol?
   var router: FeedDetailRouterProtocol?
 
-  var likeList: [LikeInfo] = []
+  private var likeList: [LikeInfo] = []
 
   // Business logic
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -10,17 +10,25 @@ import UIKit
 protocol FeedDetailInteractorProtocol {
   var worker: FeedDetailWorkerProtocol? { get set }
   var presenter: FeedDetailPresenterProtocol? { get set }
+  var router: FeedDetailRouterProtocol? { get set }
 
   func getFeedDeatil(feedId: Int)
   func fetchAllComments(feedId: Int)
   func fetchVisibleComments(comments: [Comment])
   func requestAddComment(comment: AddCommentRequest)
   func getLike(feedId: Int)
+
+  func navigateToLikeDetail(source: FeedDetailViewProtocol)
 }
 
 final class FeedDetailInteractor: FeedDetailInteractorProtocol {
   var worker: FeedDetailWorkerProtocol?
   var presenter: FeedDetailPresenterProtocol?
+  var router: FeedDetailRouterProtocol?
+
+  var likeList: [LikeInfo] = []
+
+  // Business logic
 
   func getFeedDeatil(feedId: Int) {
     self.worker?.getFeedDetail(
@@ -33,20 +41,35 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
   func getLike(feedId: Int) {
     self.worker?.getLike(
       feedId: feedId,
-      completionHandler: { [weak self] like in
-      self?.presenter?.presentLike(like: like)
-    })
+      completionHandler: { [weak self] likeList in
+        self?.likeList = likeList
+        self?.presenter?.presentLike(like: likeList)
+      })
   }
 
+  /// 전체 댓글 data fetch
   func fetchAllComments(feedId: Int) {
     self.worker?.getAllComments(
       feedId: feedId,
       completionHandler: { [weak self] comments in
+        self?.fetchAllCommentsCount(comments: comments)
         self?.fetchVisibleComments(comments: comments)
       }
     )
   }
 
+  /// 답글을 포함한 모든 댓글의 수 (헤더에 표기)
+  func fetchAllCommentsCount(comments: [Comment]) {
+    var count = comments.count
+
+    comments.forEach {
+      count += $0.commentData.reply?.count ?? 0
+    }
+    self.presenter?.presentAllCommentsCount(allCommentsCount: count)
+  }
+
+  /// 비숨김 처리 댓글 fetch
+  /// 매번 모든 댓글을 받아오지 않도록 별도 정의
   func fetchVisibleComments(comments: [Comment]) {
     self.presenter?.presentVisibleComments(allComments: comments)
   }
@@ -62,5 +85,11 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
         }
       }
     )
+  }
+
+  // Routing
+
+  func navigateToLikeDetail(source: FeedDetailViewProtocol) {
+    self.router?.navigateToLikeDetail(source: source, like: self.likeList)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -15,7 +15,7 @@ protocol FeedDetailInteractorProtocol {
   func fetchAllComments(feedId: Int)
   func fetchVisibleComments(comments: [Comment])
   func requestAddComment(comment: AddCommentRequest)
-  func getLike()
+  func getLike(feedId: Int)
 }
 
 final class FeedDetailInteractor: FeedDetailInteractorProtocol {
@@ -30,8 +30,9 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
       })
   }
 
-  func getLike() {
+  func getLike(feedId: Int) {
     self.worker?.getLike(
+      feedId: feedId,
       completionHandler: { [weak self] like in
       self?.presenter?.presentLike(like: like)
     })

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailPresenter.swift
@@ -12,7 +12,7 @@ protocol FeedDetailPresenterProtocol {
 
   func presentFeedDetail(feedDetail: FeedDetail)
   func presentVisibleComments(allComments: [Comment])
-  func presentLike(like: [Like])
+  func presentLike(like: [LikeInfo])
 }
 
 final class FeedDetailPresenter: FeedDetailPresenterProtocol {
@@ -23,7 +23,7 @@ final class FeedDetailPresenter: FeedDetailPresenterProtocol {
     LoadingIndicator.hideLoading()
   }
 
-  func presentLike(like: [Like]) {
+  func presentLike(like: [LikeInfo]) {
     self.view?.getLike(like: like)
   }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailPresenter.swift
@@ -11,6 +11,7 @@ protocol FeedDetailPresenterProtocol {
   var view: FeedDetailViewProtocol? { get set }
 
   func presentFeedDetail(feedDetail: FeedDetail)
+  func presentAllCommentsCount(allCommentsCount: Int)
   func presentVisibleComments(allComments: [Comment])
   func presentLike(like: [LikeInfo])
 }
@@ -59,6 +60,11 @@ final class FeedDetailPresenter: FeedDetailPresenterProtocol {
         }
       }
     }
-    self.view?.fetchVisibleComments(comments: comments)
+    self.view?.fetchVisibleComments(visibleComments: comments)
+  }
+
+  func presentAllCommentsCount(allCommentsCount: Int) {
+    self.view?.getAllCommentsCount(allCommentsCount: allCommentsCount)
+    print(allCommentsCount)
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol FeedDetailRouterProtocol {
   static func createFeedDetail(feedId: Int) -> UIViewController
-  func navigateToLikeDetail(source: FeedDetailViewProtocol, like: [Like])
+  func navigateToLikeDetail(source: FeedDetailViewProtocol, like: [LikeInfo])
 }
 
 final class FeedDetailRouter: FeedDetailRouterProtocol {
@@ -34,7 +34,7 @@ final class FeedDetailRouter: FeedDetailRouterProtocol {
     return view
   }
 
-  func navigateToLikeDetail(source: FeedDetailViewProtocol, like: [Like]) {
+  func navigateToLikeDetail(source: FeedDetailViewProtocol, like: [LikeInfo]) {
     let likeDetailViewController = LikeDetailViewContoller()
     if let sourceView = source as? UIViewController {
       likeDetailViewController.like = like

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
@@ -9,6 +9,7 @@ import UIKit
 
 protocol FeedDetailRouterProtocol {
   static func createFeedDetail(feedId: Int) -> UIViewController
+
   func navigateToLikeDetail(source: FeedDetailViewProtocol, like: [LikeInfo])
 }
 
@@ -26,7 +27,7 @@ final class FeedDetailRouter: FeedDetailRouterProtocol {
 
     view.feedId = feedId
     view.interactor = interactor
-    view.router = router
+    interactor.router = router
     interactor.presenter = presenter
     interactor.worker = worker
     presenter.view = view

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -270,7 +270,11 @@ extension FeedDetailViewController: UICollectionViewDataSource {
       return self.feedDetail?.data.challenges.count ?? 0
 
     case .like:
-      return self.like.count + 1
+      if self.like.isEmpty {
+        return self.like.count
+      } else {
+        return self.like.count + 1
+      }
 
     case .comment:
       return self.visibleComments.count

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -17,7 +17,7 @@ protocol FeedDetailViewProtocol: AnyObject {
   func getFeedDetail(feedDetail: FeedDetail)
   func getAllComments(allComments: [Comment])
   func fetchVisibleComments(comments: [Comment])
-  func getLike(like: [Like])
+  func getLike(like: [LikeInfo])
 }
 
 final class FeedDetailViewController: BaseViewController<FeedDetailView> {
@@ -38,7 +38,7 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
   var feedId: Int = 6
   var userId: Int = 1
   var commentId: Int?
-  var like: [Like] = []
+  var like: [LikeInfo] = []
 
   var allComments: [Comment] = []
   var visibleComments: [Comment] = [] {
@@ -59,13 +59,16 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
 
     self.setNavigationBar()
     self.setupConfigure()
-
-    self.interactor?.getFeedDeatil(feedId: feedId)
-    self.interactor?.getLike()
-    self.interactor?.fetchAllComments(feedId: feedId)
+    self.fetchData()
   }
 
   // MARK: - Configure
+
+  private func fetchData() {
+    self.interactor?.getFeedDeatil(feedId: feedId)
+    self.interactor?.getLike(feedId: feedId)
+    self.interactor?.fetchAllComments(feedId: feedId)
+  }
 
   override func setupConfigure() {
     self.containerView.postCollectionView.do {
@@ -257,7 +260,7 @@ extension FeedDetailViewController: FeedDetailViewProtocol {
     self.visibleComments = comments
   }
 
-  func getLike(like: [Like]) {
+  func getLike(like: [LikeInfo]) {
     self.like = like
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol FeedDetailWorkerProtocol {
   func getFeedDetail(feedId: Int, completionHandler: @escaping (FeedDetail) -> Void)
-  func getLike(completionHandler: @escaping ([Like]) -> Void)
+  func getLike(feedId: Int, completionHandler: @escaping ([LikeInfo]) -> Void)
   func getAllComments(feedId: Int, completionHandler: @escaping ([Comment]) -> Void)
   func requestAddComment(comment: AddCommentRequest, completionHandler: @escaping (String) -> Void)
 }
@@ -58,9 +58,9 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
     )
   }
 
-  func getLike(completionHandler: @escaping ([Like]) -> Void) {
-    self.likeRepository.getlike(completionHandler: { like in
-      completionHandler(like)
+  func getLike(feedId: Int, completionHandler: @escaping ([LikeInfo]) -> Void) {
+    self.likeRepository.getLikeList(feedId: feedId, completionHandler: { likeList in
+      completionHandler(likeList)
     })
   }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/LikeDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/LikeDetailViewController.swift
@@ -14,7 +14,7 @@ final class LikeDetailViewContoller: BaseViewController<LikeDetailView> {
 
   // MARK: - Properties
 
-  var like: [Like] = []
+  var like: [LikeInfo] = []
 
   // MARK: - Life cycle
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/Views/FeedDetailView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/Views/FeedDetailView.swift
@@ -297,15 +297,18 @@ final class FeedDetailView: UIView {
       alignment: .bottom
     )
 
+    let likeEstimatedWidth: CGFloat = 1
+    let likeEstimatedHeigth: CGFloat = 1
+
     let likeItemSize = NSCollectionLayoutSize(
-      widthDimension: .absolute(45),
-      heightDimension: .absolute(45)
+      widthDimension: .estimated(likeEstimatedWidth),
+      heightDimension: .estimated(likeEstimatedHeigth)
     )
     let likeItem = NSCollectionLayoutItem(layoutSize: likeItemSize)
 
     let likeGroupSize = NSCollectionLayoutSize(
-      widthDimension: .estimated(estimatedWidth),
-      heightDimension: .estimated(estimatedHeigth)
+      widthDimension: .estimated(likeEstimatedWidth),
+      heightDimension: .estimated(likeEstimatedHeigth)
     )
     let likeGroup = NSCollectionLayoutGroup.horizontal(
       layoutSize: likeGroupSize,
@@ -317,9 +320,9 @@ final class FeedDetailView: UIView {
     likeSection.orthogonalScrollingBehavior = .continuous
     likeSection.interGroupSpacing = 12
     likeSection.contentInsets = NSDirectionalEdgeInsets(
-      top: 15,
+      top: 10,
       leading: 20,
-      bottom: 15,
+      bottom: 10,
       trailing: 0
     )
 


### PR DESCRIPTION
## What is this PR?
- 피드 상세 내 좋아요 목록/ 좋아요 목록 상세의 데이터를 업데이트할 api를 연결하였습니다.
- 댓글의 개수가 업데이트 되지 않는 이슈를 해결하였습니다.

## Changes
- 피드 상세의 router를 interactor로 이전하였습니다.
- api 호출에 필요한 network method를 정의하였습니다.
- 좋아요의 개수가 0인 경우 좋아요 상세 목록 진입 버튼이 나타나지 않습니다.

## Test Checklist
- none.
