### PR TITLE
[FEAT] AlertViewController 정의

### DIFF
--- a/KnockKnock-iOS.xcodeproj/project.pbxproj
+++ b/KnockKnock-iOS.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		61CD47FE2934741D00FEE2F7 /* MyPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CD47FD2934741D00FEE2F7 /* MyPresenter.swift */; };
 		61CD4800293478B900FEE2F7 /* MyWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CD47FF293478B900FEE2F7 /* MyWorker.swift */; };
 		61CD48042935BC0D00FEE2F7 /* NotificationCenter+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CD48032935BC0D00FEE2F7 /* NotificationCenter+Ext.swift */; };
+		61DEFE8E2941AF9000ABC13E /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DEFE8D2941AF9000ABC13E /* AlertViewController.swift */; };
 		61E3087C287334C1001394B6 /* ImageScaleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E3087B287334C1001394B6 /* ImageScaleType.swift */; };
 		61E3088428768D71001394B6 /* UIStackView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E3088328768D71001394B6 /* UIStackView+Ext.swift */; };
 		61E87EB528D17CAF0005CAA6 /* NetworkErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E87EB428D17CAF0005CAA6 /* NetworkErrorType.swift */; };
@@ -422,6 +423,7 @@
 		61CD47FD2934741D00FEE2F7 /* MyPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPresenter.swift; sourceTree = "<group>"; };
 		61CD47FF293478B900FEE2F7 /* MyWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyWorker.swift; sourceTree = "<group>"; };
 		61CD48032935BC0D00FEE2F7 /* NotificationCenter+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationCenter+Ext.swift"; sourceTree = "<group>"; };
+		61DEFE8D2941AF9000ABC13E /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		61E3087B287334C1001394B6 /* ImageScaleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageScaleType.swift; sourceTree = "<group>"; };
 		61E3088328768D71001394B6 /* UIStackView+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Ext.swift"; sourceTree = "<group>"; };
 		61E87EB428D17CAF0005CAA6 /* NetworkErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorType.swift; sourceTree = "<group>"; };
@@ -574,9 +576,9 @@
 		201A288127BAAFDE004F7CD9 /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
+				61DEFE8B2941AF6F00ABC13E /* Alert */,
 				61A0283A29090B1C00943A40 /* BottomSheet */,
 				61C21CFB28C463CD009B5F4E /* Default */,
-				618D8B4A28BB355E00828794 /* AlertView.swift */,
 				61FC60EC27B9244E00A51DBC /* MainTabBarController.swift */,
 				201077F027D3A94800280991 /* BaseComponent */,
 				201077FA27D3D24600280991 /* Cells */,
@@ -1066,6 +1068,23 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		61DEFE8B2941AF6F00ABC13E /* Alert */ = {
+			isa = PBXGroup;
+			children = (
+				61DEFE8C2941AF7A00ABC13E /* Views */,
+				61DEFE8D2941AF9000ABC13E /* AlertViewController.swift */,
+			);
+			path = Alert;
+			sourceTree = "<group>";
+		};
+		61DEFE8C2941AF7A00ABC13E /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				618D8B4A28BB355E00828794 /* AlertView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		61E3087A2873349B001394B6 /* Enum */ = {
 			isa = PBXGroup;
 			children = (
@@ -1474,6 +1493,7 @@
 				61AB2E4828A0A7E900A1AE30 /* HomeTagCell.swift in Sources */,
 				6143294D285DD2A0008BDCC9 /* FeedMainFooterCollectionReusableView.swift in Sources */,
 				611BD4A527E3080B007D5C79 /* FeedWriteView.swift in Sources */,
+				61DEFE8E2941AF9000ABC13E /* AlertViewController.swift in Sources */,
 				618D8B6028BDF6C900828794 /* SearchTap.swift in Sources */,
 				201077F827D3BF4B00280991 /* Array+Ext.swift in Sources */,
 				20D28F8627CFC7B300A809DB /* ChallengeWorker.swift in Sources */,

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIButton+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIButton+Ext.swift
@@ -8,7 +8,9 @@
 import UIKit
 
 extension UIButton {
-  
+
+  /// image와 title를 수직 배치 하기 위한 메소드
+  /// spacing: image, title 사이 간격
   func alignTextBelow(spacing: CGFloat) {
     guard let image = self.imageView?.image,
           let titleLabel = self.titleLabel,
@@ -21,11 +23,69 @@ extension UIButton {
       top: spacing,
       left: -image.size.width,
       bottom: -image.size.height,
-      right: 0)
+      right: 0
+    )
     imageEdgeInsets = UIEdgeInsets(
       top: -(titleSize.height + spacing),
       left: 0,
       bottom: 0,
-      right: -titleSize.width)
+      right: -titleSize.width
+    )
+  }
+}
+
+// MARK: - UIButton event를 closure를 이용하여 정의하기
+
+extension UIButton {
+
+  public typealias UIButtonTargetClosure = (UIButton) -> Void
+
+  private class UIButtonClosureWrapper: NSObject {
+    let closure: UIButtonTargetClosure
+    init(_ closure: @escaping UIButtonTargetClosure) {
+      self.closure = closure
+    }
+  }
+
+  private struct AssociatedKeys {
+    static var targetClosure = "targetClosure"
+  }
+
+  private var targetClosure: UIButtonTargetClosure? {
+    get {
+      guard let closureWrapper = objc_getAssociatedObject(
+        self,
+        &AssociatedKeys.targetClosure) as? UIButtonClosureWrapper else { return nil }
+
+      return closureWrapper.closure
+    }
+    set(newValue) {
+      guard let newValue = newValue else { return }
+
+      objc_setAssociatedObject(
+        self,
+        &AssociatedKeys.targetClosure,
+        UIButtonClosureWrapper(newValue),
+        objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+      )
+    }
+  }
+
+  @objc func closureAction() {
+    guard let targetClosure = targetClosure else { return }
+    targetClosure(self)
+  }
+
+  public func addAction(
+    for event: UIButton.Event,
+    closure: @escaping UIButtonTargetClosure
+  ) {
+    targetClosure = closure
+
+    addTarget(
+      self,
+      action: #selector(UIButton.closureAction),
+      for: event
+    )
   }
 }

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIViewController+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIViewController+Ext.swift
@@ -11,12 +11,38 @@ extension UIViewController {
 
   /// 화면을 tap 했을 때 Keyboard가 내려가도록 하는 메소드
   func hideKeyboardWhenTappedAround() {
-    let tap = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+    let tap = UITapGestureRecognizer(
+      target: self,
+      action: #selector(UIViewController.dismissKeyboard)
+    )
     tap.cancelsTouchesInView = false
     view.addGestureRecognizer(tap)
   }
 
   @objc func dismissKeyboard() {
     view.endEditing(true)
+  }
+
+  /// Alert View 생성 및 present
+  /// content: alert message
+  /// isCancelActive: 취소 버튼 활성화 유무
+  /// confirmActionCompletion: 확인 버튼 클릭 이벤트
+  func showAlert(
+    content: String,
+    isCancelActive: Bool = true,
+    confirmActionCompletion: (() -> Void)?
+  ) {
+    let alertViewController = AlertViewController(
+      content: content,
+      isCancelActive: isCancelActive
+    )
+
+    alertViewController.addActionToConfirmButton() {
+      alertViewController.dismiss(
+        animated: false,
+        completion: confirmActionCompletion
+      )
+    }
+    self.present(alertViewController, animated: false, completion: nil)
   }
 }

--- a/KnockKnock-iOS/Scenes/Alert/AlertViewController.swift
+++ b/KnockKnock-iOS/Scenes/Alert/AlertViewController.swift
@@ -1,0 +1,49 @@
+//
+//  AlertViewController.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2022/12/08.
+//
+
+import UIKit
+
+final class AlertViewController: BaseViewController<AlertView> {
+
+  // MARK: - Initialize
+
+  convenience init(
+    content: String,
+    isCancelActive: Bool
+  ) {
+    self.init()
+
+    self.containerView.bind(
+      content: content,
+      isCancelActive: isCancelActive
+    )
+    self.modalPresentationStyle = .overFullScreen
+  }
+
+  // MARK: - Life Cycles
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.configure()
+  }
+
+  // MARK: - Configure
+
+  private func configure() {
+    self.containerView.backgroundColor = .black.withAlphaComponent(0.5)
+
+    self.containerView.cancelButton.addAction(for: .touchUpInside) { _ in
+      self.dismiss(animated: false)
+    }
+  }
+
+  func addActionToConfirmButton(completion: (() -> Void)? = nil) {
+    self.containerView.confirmButton.addAction(for: .touchUpInside) { _ in
+      completion?()
+    }
+  }
+}

--- a/KnockKnock-iOS/Scenes/Alert/Views/AlertView.swift
+++ b/KnockKnock-iOS/Scenes/Alert/Views/AlertView.swift
@@ -12,6 +12,10 @@ import Then
 
 final class AlertView: UIView {
 
+  // MARK: - Properties
+
+  private var content: String?
+
   // MARK: - Constants
 
   private enum Metric {
@@ -27,10 +31,6 @@ final class AlertView: UIView {
   }
 
   // MARK: - UIs
-
-  private let dimmedView = UIView().then {
-    $0.backgroundColor = UIColor(displayP3Red: 0, green: 0, blue: 0, alpha: 0.5)
-  }
 
   private let alertView = UIView().then {
     $0.backgroundColor = .white
@@ -75,15 +75,11 @@ final class AlertView: UIView {
     self.contentLabel.text = content
   }
 
-  // MARK: - Configure
+  // MARK: - Constraints
 
   private func setupConstraints() {
-    [self.dimmedView, self.alertView].addSubViews(self)
+    [self.alertView].addSubViews(self)
     [self.contentLabel, self.cancelButton, self.confirmButton].addSubViews(self.alertView)
-
-    self.dimmedView.snp.makeConstraints {
-      $0.edges.equalToSuperview()
-    }
 
     self.alertView.snp.makeConstraints {
       $0.centerY.equalToSuperview()

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -149,6 +149,7 @@ extension FeedMainViewController: FeedMainViewProtocol {
 }
 
 // MARK: - SearchTextField Delegate
+
 extension FeedMainViewController: UISearchBarDelegate {
   func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
     if let keyword = searchBar.searchTextField.text {

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
@@ -54,13 +54,7 @@ final class ProfileSettingViewController: BaseViewController<ProfileSettingView>
         for: .touchUpInside
       )
     }
-    self.containerView.alertView.confirmButton.do {
-      $0.addTarget(
-        self,
-        action: #selector(self.alertConfirmButtonDidTap(_:)),
-        for: .touchUpInside
-      )
-    }
+
     self.hideKeyboardWhenTappedAround()
   }
 
@@ -84,23 +78,22 @@ final class ProfileSettingViewController: BaseViewController<ProfileSettingView>
       image: ""
     )
 
-    self.containerView.do {
-      $0.setHiddenStatusAlertView(isHidden: false)
-    }
-  }
-
-  @objc private func alertConfirmButtonDidTap(_ sender: UIButton) {
-    self.interactor?.router?.navigateToMyView(source: self)
+    self.showAlert(
+      content: "프로필 등록을 완료하였습니다.",
+      confirmActionCompletion: {
+        self.interactor?.router?.navigateToMyView(source: self)
+      }
+    )
   }
 }
 
-  // MARK: - Profile Setting View Protocol
+// MARK: - Profile Setting View Protocol
 
 extension ProfileSettingViewController: ProfileSettingViewProtocol {
   
 }
 
-  // MARK: - TextField delegate
+// MARK: - TextField delegate
 
 extension ProfileSettingViewController: UITextFieldDelegate {
   func textFieldDidEndEditing(_ textField: UITextField) {

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/Views/ProfileSettingView.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/Views/ProfileSettingView.swift
@@ -74,11 +74,6 @@ final class ProfileSettingView: UIView {
     $0.isEnabled = false
   }
 
-  let alertView = AlertView().then {
-    $0.isHidden = true
-    $0.bind(content: "프로필 등록을 완료하였습니다.", isCancelActive: false)
-  }
-
   // MARK: - Initialize
 
   override init(frame: CGRect) {
@@ -92,10 +87,6 @@ final class ProfileSettingView: UIView {
 
   // MARK: - Bind
 
-  func setHiddenStatusAlertView(isHidden: Bool) {
-    self.alertView.isHidden = isHidden
-  }
-
   func bind(isClicked: Bool) {
     if isClicked {
       self.nicknameTextField.layer.borderColor = KKDS.Color.green50.cgColor
@@ -108,7 +99,7 @@ final class ProfileSettingView: UIView {
 
   private func setupConstraints() {
 
-    [self.profileImageView, self.cameraImageView, self.profileButton, self.nicknameTextField, self.noticeLabel, self.confirmButton, self.alertView].addSubViews(self)
+    [self.profileImageView, self.cameraImageView, self.profileButton, self.nicknameTextField, self.noticeLabel, self.confirmButton].addSubViews(self)
 
     self.profileImageView.snp.makeConstraints {
       $0.centerX.equalTo(self.safeAreaLayoutGuide)
@@ -141,10 +132,6 @@ final class ProfileSettingView: UIView {
       $0.leading.trailing.equalTo(self.safeAreaLayoutGuide).inset(Metric.confirmButtonLeadingMargin)
       $0.bottom.equalTo(self.safeAreaLayoutGuide).offset(Metric.confirmButtonBottomMargin)
       $0.height.equalTo(Metric.confirmButtonHeight)
-    }
-
-    self.alertView.snp.makeConstraints {
-      $0.edges.equalToSuperview()
     }
   }
 }


### PR DESCRIPTION
## What is this PR?
- 알림창 노출에 사용 될 AlertViewController를 정의하였습니다.
- 클로저를 통해 버튼 액션을 정의할 수 있도록 하였습니다.

## Changes
- 이니셜라이저를 통하여 `AlertViewController` 생성 시 메세지 내용, 취소 버튼 유무, 확인 버튼 액션을 설정합니다.
- `UIViewController extension`에 `showAlert`메소드를 만들어 알림창이 필요한 화면에서 호출하여 사용할 수 있습니다.

## Test Checklist
- none.