### PR TITLE
[FIX] 피드 리스트 entity userimage type 수정(string -> string?)

### DIFF
--- a/KnockKnock-iOS/Entity/FeedPost.swift
+++ b/KnockKnock-iOS/Entity/FeedPost.swift
@@ -25,7 +25,6 @@ struct Property: Equatable {
   let title: String
 }
 
-
 struct FeedDetail: Decodable {
   let data: FeedDetailData
 }
@@ -105,7 +104,7 @@ struct FeedList: Decodable {
 struct FeedListPost: Decodable {
   let id: Int
   let userName: String
-  let userImage: String
+  let userImage: String?
   let regDateToString: String
   let content: String?
   let imageScale: String = "1:1"


### PR DESCRIPTION
## What is this PR?
- 서버 명세 변경으로 인하여 데이터를 받아올 수 없는 오류를 해결합니다.

## Changes
- 피드리스트 entity의 `userImage` type을 `Optional String`으로 변경하여 `null` 상태의 데이터도 받아올 수 있도록 처리하였습니다.

## Test Checklist
- none.