### PR TITLE
[FEAT] 게시글 등록 시 token 인증 추가

### DIFF
--- a/KnockKnock-iOS/Entity/FeedWrite.swift
+++ b/KnockKnock-iOS/Entity/FeedWrite.swift
@@ -11,7 +11,6 @@ import UIKit
 
 /// 피드 등록 entity
 struct FeedWrite {
-  let userId: Int
   let content: String
   let storeAddress: String
   let locationX: String

--- a/KnockKnock-iOS/Network/KKNetworkManager.swift
+++ b/KnockKnock-iOS/Network/KKNetworkManager.swift
@@ -44,7 +44,8 @@ final class KKNetworkManager {
   ) {
     AF.upload(
       multipartFormData: router.multipart,
-      with: router
+      with: router,
+      interceptor: self.interceptor
     ).validate(statusCode: 200..<500)
       .responseData { response in
         switch response.result {

--- a/KnockKnock-iOS/Network/KKRouter.swift
+++ b/KnockKnock-iOS/Network/KKRouter.swift
@@ -189,7 +189,6 @@ enum KKRouter: URLRequestConvertible {
 
       let multipartFormData = MultipartFormData()
 
-      let userId = "\(feedWriteForm.userId)".data(using: .utf8) ?? Data()
       let content = feedWriteForm.content.data(using: .utf8) ?? Data()
       let storeAddress = feedWriteForm.storeAddress.data(using: .utf8) ?? Data()
       let locationX = feedWriteForm.locationX.data(using: .utf8) ?? Data()
@@ -199,7 +198,6 @@ enum KKRouter: URLRequestConvertible {
       let challenges = feedWriteForm.challenges.data(using: .utf8) ?? Data()
       let images = feedWriteForm.images.map { $0.pngData() ?? Data() }
 
-      multipartFormData.append(userId, withName: "userId")
       multipartFormData.append(content, withName: "content")
       multipartFormData.append(storeAddress, withName: "storeAddress")
       multipartFormData.append(locationX, withName: "locationX")

--- a/KnockKnock-iOS/Scenes/Cells/FeedCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/FeedCell.swift
@@ -37,7 +37,7 @@ class FeedCell: BaseCollectionViewCell {
   func bind(post: FeedMainPost) {
     self.severalSymbolImageView.isHidden = !post.isImageMore
     self.thumbnailImageView.setImageFromStringUrl(
-      url: "https://dy-yb.github.io/images/profile.jpg", // post.thumbnailUrl
+      url: post.thumbnailUrl,
       defaultImage: KKDS.Image.ic_no_data_60
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -41,7 +41,7 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
   var popularPost: [String] = []
   
   var currentPage = 1
-  let pageSize = 1 // pageSize 논의 필요, 페이지네이션 작동 테스트를 위해 1로 임시 설정
+  let pageSize = 9 // pageSize 논의 필요, 페이지네이션 작동 테스트를 위해 1로 임시 설정
   var challengeId = 0
 
   // MARK: - UIs

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/Views/FeedMainView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/Views/FeedMainView.swift
@@ -158,7 +158,7 @@ class FeedMainView: UIView {
     // footer
     let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(50.0))
     let footer = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: footerSize, elementKind: UICollectionView.elementKindSectionFooter, alignment: .bottom)
-    footer.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
+    footer.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 100, trailing: 0)
 
     section.boundarySupplementaryItems = [footer]
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteInteractor.swift
@@ -22,7 +22,7 @@ protocol FeedWriteInteractorProtocol: AnyObject {
 
   func setCurrentText(text: String) 
   func checkEssentialField(imageCount: Int)
-  func requestUploadFeed(source: FeedWriteViewProtocol, userId: Int, content: String, images: [UIImage])
+  func requestUploadFeed(source: FeedWriteViewProtocol, content: String, images: [UIImage])
 }
 
 final class FeedWriteInteractor: FeedWriteInteractorProtocol {
@@ -78,7 +78,6 @@ final class FeedWriteInteractor: FeedWriteInteractorProtocol {
 
   func requestUploadFeed(
     source: FeedWriteViewProtocol,
-    userId: Int,
     content: String,
     images: [UIImage]
   ) {
@@ -96,7 +95,6 @@ final class FeedWriteInteractor: FeedWriteInteractorProtocol {
 
     self.worker?.uploadFeed(
       postData: FeedWrite(
-        userId: userId,
         content: content,
         storeAddress: self.selectedAddress?.addressName ?? "",
         locationX: self.selectedAddress?.longtitude ?? "",

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
@@ -184,7 +184,6 @@ extension FeedWriteViewController: FeedWriteViewProtocol {
       self.showAlert(content: "게시글 등록을 완료 하시겠습니까?", confirmActionCompletion: {
         self.interactor?.requestUploadFeed(
           source: self,
-          userId: 19, // api 수정 필요
           content: self.containerView.contentTextView.text,
           images: self.selectedImages
         )


### PR DESCRIPTION
## What is this PR?
- 피드 게시글을 등록할때 userid를 직접 입력받았던 방식을 accessToken 인증을 통해 이루어지도록 변경하였습니다.

## Changes
- Alamofire upload시 interceptor를 이용하여 토큰인증이 이루어집니다.
- request body의 userid가 삭제되었습니다.

## Test Checklist
- none.