### PR TITLE
[FIX] 매장 관련 데이터가 입력 되지 않았을 때 빈값("")으로 전달 되는 문제 수정

### DIFF
--- a/KnockKnock-iOS/Entity/Feed/FeedWrite.swift
+++ b/KnockKnock-iOS/Entity/Feed/FeedWrite.swift
@@ -12,7 +12,7 @@ import UIKit
 /// 피드 등록 entity
 struct FeedWrite {
   let content: String
-  let storeAddress: String
+  let storeAddress: String?
   let storeName: String?
   let locationX: String
   let locationY: String

--- a/KnockKnock-iOS/Network/KKRouter.swift
+++ b/KnockKnock-iOS/Network/KKRouter.swift
@@ -194,7 +194,8 @@ enum KKRouter: URLRequestConvertible {
       let multipartFormData = MultipartFormData()
 
       let content = feedWriteForm.content.data(using: .utf8) ?? Data()
-      let storeAddress = feedWriteForm.storeAddress.data(using: .utf8) ?? Data()
+      let storeAddress = feedWriteForm.storeAddress?.data(using: .utf8)
+      let storeName = feedWriteForm.storeName?.data(using: .utf8)
       let locationX = feedWriteForm.locationX.data(using: .utf8) ?? Data()
       let locationY = feedWriteForm.locationY.data(using: .utf8) ?? Data()
       let scale = feedWriteForm.scale.data(using: .utf8) ?? Data()
@@ -203,7 +204,11 @@ enum KKRouter: URLRequestConvertible {
       let images = feedWriteForm.images.map { $0.pngData() ?? Data() }
 
       multipartFormData.append(content, withName: "content")
-      multipartFormData.append(storeAddress, withName: "storeAddress")
+      if let storeName = storeName,
+         let storeAddress = storeAddress {
+        multipartFormData.append(storeAddress, withName: "storeAddress")
+        multipartFormData.append(storeName, withName: "storeName")
+      }
       multipartFormData.append(locationX, withName: "locationX")
       multipartFormData.append(locationY, withName: "locationY")
       multipartFormData.append(scale, withName: "scale")


### PR DESCRIPTION
## What is this PR?
- 주소가 입력 되지 않았을 때 `nil`이 아닌 `""`으로 db에 저장되는 이슈를 해결하였습니다.

## Changes
- 주소 관련 데이터 타입을 재정의하고 api 요청 시 입력된 값이 없으면 `""`이 아닌 `nil`로 전달되도록 수정하였습니다.

## Test Checklist
- none.