### PR TITLE
[FIX] 키보드 활성화 시 댓글 입력창이 가려지지 않도록 수정

### DIFF
--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentViewController.swift
@@ -100,18 +100,10 @@ final class CommentViewController: BaseViewController<CommentView> {
   
   @objc private func keyboardWillShow(_ notification: Notification) {
     self.setContainerViewConstant(notification: notification, isAppearing: true)
-    self.setCommentsTextViewConstant(isAppearing: true)
   }
   
   @objc private func keyboardWillHide(_ notification: Notification) {
     self.setContainerViewConstant(notification: notification, isAppearing: false)
-    self.setCommentsTextViewConstant(isAppearing: false)
-  }
-  
-  private func setCommentsTextViewConstant(isAppearing: Bool) {
-    let textViewHeightConstant = isAppearing ? 15.f : -19.f
-    
-    self.containerView.commentTextView.bottomConstraint?.constant = textViewHeightConstant
   }
   
   private func setContainerViewConstant(notification: Notification, isAppearing: Bool) {
@@ -126,11 +118,18 @@ final class CommentViewController: BaseViewController<CommentView> {
           .keyboardAnimationDurationUserInfoKey
       ] as? NSNumber else { return }
       
-      let viewHeightConstant = isAppearing ? (-keyboardHeight) : 0
-      
-      self.containerView.contentView.frame.origin.y = viewHeightConstant + 100
+      let viewBottomConstant = isAppearing ? (-keyboardHeight) : 0
+      let textViewBottomConstant = isAppearing ? 15.f : -19.f
       
       UIView.animate(withDuration: animationDurationValue.doubleValue) {
+        self.containerView.contentView.snp.updateConstraints {
+          $0.bottom.equalTo(self.containerView.safeAreaLayoutGuide).offset(viewBottomConstant)
+        }
+
+        self.containerView.commentTextView.snp.updateConstraints {
+          $0.bottom.equalTo(self.containerView.contentView).offset(textViewBottomConstant)
+        }
+
         self.containerView.layoutIfNeeded()
       }
     }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -241,7 +241,10 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
 
     if self.containerView.commentTextView.text.isEmpty {
       self.containerView.likeButton.isHidden = false
-      self.containerView.commentTextView.leadingConstraint?.constant = 0
+      
+      self.containerView.commentTextView.snp.updateConstraints {
+        $0.leading.equalTo(self.containerView.likeButton.snp.trailing)
+      }
     }
   }
   
@@ -266,14 +269,14 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
           .keyboardAnimationDurationUserInfoKey
       ] as? NSNumber else { return }
       
-      let viewHeightConstant = isAppearing ? (-keyboardHeight) : 0
+      let viewBottomConstant = isAppearing ? (-keyboardHeight) : 0
 
       UIView.animate(withDuration: animationDurationValue.doubleValue) {
         self.containerView.postCollectionView.snp.updateConstraints {
-          $0.bottom.equalTo(self.containerView.safeAreaLayoutGuide).offset(viewHeightConstant)
+          $0.bottom.equalTo(self.containerView.safeAreaLayoutGuide).offset(viewBottomConstant)
         }
         self.containerView.commentTextView.snp.updateConstraints {
-          $0.bottom.equalTo(self.containerView.safeAreaLayoutGuide).offset(viewHeightConstant)
+          $0.bottom.equalTo(self.containerView.safeAreaLayoutGuide).offset(viewBottomConstant)
         }
         self.containerView.layoutIfNeeded()
       }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -231,14 +231,13 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
   
   @objc private func keyboardWillShow(_ notification: Notification) {
     self.setCommentsTextViewConstant(isAppearing: true)
-    self.setContainerViewConstant(notification: notification, isAppearing: true)
+//    self.setContainerViewConstant(notification: notification, isAppearing: true)
     self.containerView.likeButton.isHidden = true
   }
   
   @objc private func keyboardWillHide(_ notification: Notification) {
     self.setCommentsTextViewConstant(isAppearing: false)
-    self.setContainerViewConstant(notification: notification, isAppearing: false)
-    
+
     if self.containerView.commentTextView.text.isEmpty {
       self.containerView.likeButton.isHidden = false
       self.containerView.commentTextView.leadingConstraint?.constant = 0
@@ -269,6 +268,7 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
       self.containerView.frame.origin.y = viewHeightConstant
       
       UIView.animate(withDuration: animationDurationValue.doubleValue) {
+        self.setContainerViewConstant(notification: notification, isAppearing: isAppearing)
         self.containerView.layoutIfNeeded()
       }
     }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -231,12 +231,13 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
   
   @objc private func keyboardWillShow(_ notification: Notification) {
     self.setCommentsTextViewConstant(isAppearing: true)
-//    self.setContainerViewConstant(notification: notification, isAppearing: true)
+    self.setContainerViewConstant(notification: notification, isAppearing: true)
     self.containerView.likeButton.isHidden = true
   }
   
   @objc private func keyboardWillHide(_ notification: Notification) {
     self.setCommentsTextViewConstant(isAppearing: false)
+    self.setContainerViewConstant(notification: notification, isAppearing: false)
 
     if self.containerView.commentTextView.text.isEmpty {
       self.containerView.likeButton.isHidden = false
@@ -246,9 +247,11 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
   
   private func setCommentsTextViewConstant(isAppearing: Bool) {
     let textViewHeightConstant = isAppearing ? 15.f : -19.f
-    
-    self.containerView.commentTextView.bottomConstraint?.constant = textViewHeightConstant
-    self.containerView.commentTextView.leadingConstraint?.constant = -20
+
+    self.containerView.commentTextView.snp.updateConstraints {
+      $0.bottom.equalTo(self.containerView.safeAreaLayoutGuide).offset(textViewHeightConstant)
+      $0.leading.equalTo(self.containerView.likeButton.snp.trailing).offset(-20)
+    }
   }
   
   private func setContainerViewConstant(notification: Notification, isAppearing: Bool) {
@@ -264,11 +267,14 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
       ] as? NSNumber else { return }
       
       let viewHeightConstant = isAppearing ? (-keyboardHeight) : 0
-      
-      self.containerView.frame.origin.y = viewHeightConstant
-      
+
       UIView.animate(withDuration: animationDurationValue.doubleValue) {
-        self.setContainerViewConstant(notification: notification, isAppearing: isAppearing)
+        self.containerView.postCollectionView.snp.updateConstraints {
+          $0.bottom.equalTo(self.containerView.safeAreaLayoutGuide).offset(viewHeightConstant)
+        }
+        self.containerView.commentTextView.snp.updateConstraints {
+          $0.bottom.equalTo(self.containerView.safeAreaLayoutGuide).offset(viewHeightConstant)
+        }
         self.containerView.layoutIfNeeded()
       }
     }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/Views/FeedDetailView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/Views/FeedDetailView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import KKDSKit
+import SnapKit
 import Then
 
 final class FeedDetailView: UIView {
@@ -52,7 +53,6 @@ final class FeedDetailView: UIView {
     collectionViewLayout: UICollectionViewFlowLayout().then {
       $0.scrollDirection = .horizontal
     }).then {
-      $0.translatesAutoresizingMaskIntoConstraints = false
       $0.backgroundColor = .clear
       $0.contentInset = .init(
         top: 0,
@@ -63,7 +63,6 @@ final class FeedDetailView: UIView {
     }
 
   private let imagePageControl = UIPageControl().then {
-    $0.translatesAutoresizingMaskIntoConstraints = false
     $0.currentPage = 0
     $0.pageIndicatorTintColor = UIColor(
       red: 255/255,
@@ -82,7 +81,6 @@ final class FeedDetailView: UIView {
       bottom: 7,
       right: 15
     )).then {
-      $0.translatesAutoresizingMaskIntoConstraints = false
       $0.backgroundColor = UIColor(
         red: 34/255,
         green: 34/255,
@@ -98,7 +96,6 @@ final class FeedDetailView: UIView {
     }
 
   let commentInputView = UIView().then {
-    $0.translatesAutoresizingMaskIntoConstraints = false
     $0.backgroundColor = .white
     $0.layer.borderWidth = 1
     $0.layer.borderColor = UIColor.white.cgColor
@@ -109,13 +106,11 @@ final class FeedDetailView: UIView {
   }
 
   let likeButton = UIButton().then {
-    $0.translatesAutoresizingMaskIntoConstraints = false
     $0.setImage(KKDS.Image.ic_like_24_off, for: .normal)
     $0.setImage(KKDS.Image.ic_like_24_on, for: .selected)
   }
 
   lazy var commentTextView = UITextView().then {
-    $0.translatesAutoresizingMaskIntoConstraints = false
     $0.text = self.commentTextViewPlaceholder
     $0.textColor = .gray50
     $0.font = .systemFont(ofSize: 15, weight: .regular)
@@ -124,7 +119,6 @@ final class FeedDetailView: UIView {
   }
 
   let registButton = UIButton().then {
-    $0.translatesAutoresizingMaskIntoConstraints = false
     $0.setTitle("등록", for: .normal)
     $0.titleLabel?.font = .systemFont(ofSize: 13, weight: .bold)
     $0.clipsToBounds = true
@@ -167,34 +161,36 @@ final class FeedDetailView: UIView {
   func setupConstraints() {
     [self.postCollectionView].addSubViews(self)
 
-    NSLayoutConstraint.activate([
-      self.postCollectionView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
-      self.postCollectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-      self.postCollectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-      self.postCollectionView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor)
-    ])
+    self.postCollectionView.snp.makeConstraints {
+      $0.top.bottom.equalTo(self.safeAreaLayoutGuide)
+      $0.leading.trailing.equalTo(self)
+    }
 
     [self.commentInputView, self.likeButton, self.commentTextView, self.registButton].addSubViews(self)
 
-    NSLayoutConstraint.activate([
-      self.commentInputView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor),
-      self.commentInputView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor),
-      self.commentInputView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
-      self.commentInputView.topAnchor.constraint(equalTo: self.commentTextView.topAnchor, constant: Metric.commentInputViewTopMargin),
+    self.commentInputView.snp.makeConstraints {
+      $0.top.equalTo(self.commentTextView).offset(Metric.commentInputViewTopMargin)
+      $0.bottom.leading.trailing.equalTo(self.safeAreaLayoutGuide)
+    }
 
-      self.likeButton.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: Metric.likeButtonLeadingMargin),
-      self.likeButton.centerYAnchor.constraint(equalTo: self.commentTextView.centerYAnchor),
+    self.likeButton.snp.makeConstraints {
+      $0.leading.equalTo(self.safeAreaLayoutGuide).offset(Metric.likeButtonLeadingMargin)
+      $0.centerY.equalTo(self.commentTextView)
+    }
 
-      self.commentTextView.heightAnchor.constraint(equalToConstant: Metric.commentTextViewHeight),
-      self.commentTextView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: Metric.commentTextViewBottomMargin),
-      self.commentTextView.trailingAnchor.constraint(equalTo: self.registButton.leadingAnchor, constant: Metric.commentTextViewTrailingMargin),
-      self.commentTextView.leadingAnchor.constraint(equalTo: self.likeButton.trailingAnchor, constant: Metric.commentTextViewLeadingMargin),
+    self.commentTextView.snp.makeConstraints {
+      $0.height.equalTo(Metric.commentTextViewHeight)
+      $0.bottom.equalTo(self.safeAreaLayoutGuide).offset(Metric.commentTextViewBottomMargin)
+      $0.trailing.equalTo(self.registButton.snp.leading).offset(Metric.commentTextViewTrailingMargin)
+      $0.leading.equalTo(self.likeButton.snp.trailing).offset(Metric.commentTextViewLeadingMargin)
+    }
 
-      self.registButton.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: Metric.registButtonTrailingMargin),
-      self.registButton.bottomAnchor.constraint(equalTo: self.commentTextView.bottomAnchor),
-      self.registButton.widthAnchor.constraint(equalToConstant: Metric.registButtonWidth),
-      self.registButton.heightAnchor.constraint(equalToConstant: Metric.registButtonHeight)
-    ])
+    self.registButton.snp.makeConstraints {
+      $0.trailing.equalTo(self.safeAreaLayoutGuide).offset(Metric.registButtonTrailingMargin)
+      $0.bottom.equalTo(self.commentTextView.snp.bottom)
+      $0.width.equalTo(Metric.registButtonWidth)
+      $0.height.equalTo(Metric.registButtonHeight)
+    }
   }
 
   func createDefaultSection() -> NSCollectionLayoutSection {


### PR DESCRIPTION
## What is this PR?
- 게시글 상세(FeedDetail), 댓글 보기(Comment) 화면에서 댓글 입력창을 눌러 키보드가 활성화 되었을 때 입력창이 키보드에 가려 보이지 않는 문제를 해결하였습니다.

## Changes
- autolayout 구현 방식을 Snapkit을 적용하였습니다.
- 기존에 키보드가 활성화되면 전체 화면이 올라가도록 구현하였으나, 키보드를 내리지 않으면 상단측의 내용을 확인할 수 없는 문제가 있어, collectionView의 bottom 값을 수정하는 것으로 변경하였습니다.

## Test Checklist
- none.
