### PR TITLE
[FIX] 사진 등록 버튼을 누를 때 마다 선택한 사진이 초기화 되는 문제 해결

### DIFF
--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
@@ -139,7 +139,7 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
   // MARK: - ImagePicker
 
   func callImagePicker() {
-    self.selectedImages = []
+    var images: [UIImage] = []
 
     let picker = ImagePickerManager.shared.setImagePicker()
 
@@ -147,7 +147,9 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
       for item in items {
         switch item {
         case let .photo(photo):
-          self.selectedImages.append(photo.image)
+          images.append(photo.image)
+          self.selectedImages = images
+
           self.containerView.photoCollectionView.reloadData()
         default:
           print("error")


### PR DESCRIPTION
## What is this PR?
- 피드 등록 화면 내의 사진 등록 버튼을 누를 때마다(사진을 선택하지 않아도) 선택 한 사진이 초기화 되어 기존에 선택한 내용을 게시글 등록에 적용할 수 없는 문제를 해결하였습니다.

- 수정 전

https://user-images.githubusercontent.com/40792935/213059034-d721bc01-85fe-43b7-8e6e-84832978220f.mov


- 수정 후

https://user-images.githubusercontent.com/40792935/213058991-1df411fb-86dc-4dec-9695-383bec665743.MP4



## Changes
- 선택 된 사진을 저장하는 변수의 초기화 방식을 수정하였습니다.

## Test Checklist
- None.