### PR TITLE
[FEAT] 회원가입 시 이미지 첨부

### DIFF
--- a/KnockKnock-iOS/Entity/Account.swift
+++ b/KnockKnock-iOS/Entity/Account.swift
@@ -5,12 +5,20 @@
 //  Created by Daye on 2022/11/01.
 //
 
-import Foundation
+import UIKit
 
 /// 로그인 요청시 request body에 사용
 struct SignInInfo {
   let socialUuid: String
   let socialType: String
+}
+
+/// 회원가입 요청
+struct RegisterInfo {
+  let socialUuid: String
+  let socialType: String
+  let nickname: String
+  let image: UIImage
 }
 
 /// 로그인/회원가입 응답 값

--- a/KnockKnock-iOS/Network/KKRouter.swift
+++ b/KnockKnock-iOS/Network/KKRouter.swift
@@ -27,7 +27,7 @@ enum KKRouter: URLRequestConvertible {
 
   // Account
   case postSocialLogin(signInInfo: Parameters)
-  case postSignUp(userInfo: Parameters)
+  case postSignUp(userInfo: RegisterInfo)
   case deleteWithdraw
   case postLogOut
 
@@ -137,8 +137,8 @@ enum KKRouter: URLRequestConvertible {
     case let .postSocialLogin(signInInfo):
       return signInInfo
 
-    case let .postSignUp(userInfo):
-      return userInfo
+//    case let .postSignUp(userInfo):
+//      return userInfo
 
     case let .requestShopAddress(query, page, size):
       return [
@@ -170,16 +170,16 @@ enum KKRouter: URLRequestConvertible {
          .getChallengeTitles,
          .getFeed,
          .getPromotions,
-         .postFeedLike,
-         .deleteFeedLike,
          .getLikeList,
+         .getComment,
+         .postFeedLike,
          .postFeed,
          .postLogOut,
+         .postSignUp,
+         .deleteFeedLike,
          .deleteComment,
          .deleteFeed,
-         .deleteWithdraw,
-         .getComment:
-
+         .deleteWithdraw:
       return nil
     }
   }
@@ -216,6 +216,21 @@ enum KKRouter: URLRequestConvertible {
       images.forEach {
         multipartFormData.append($0, withName: "images", fileName: "\($0).png", mimeType: "image/png")
       }
+
+      return multipartFormData
+
+    case .postSignUp(let userInfo):
+      let multipartFormData = MultipartFormData()
+
+      let socialUuid = userInfo.socialUuid.data(using: .utf8) ?? Data()
+      let socialType = userInfo.socialType.data(using: .utf8) ?? Data()
+      let nickname = userInfo.nickname.data(using: .utf8) ?? Data()
+      let image = userInfo.image.pngData() ?? Data()
+
+      multipartFormData.append(socialUuid, withName: "socialUuid")
+      multipartFormData.append(socialType, withName: "socialType")
+      multipartFormData.append(nickname, withName: "nickname")
+      multipartFormData.append(image, withName: "image", fileName: "\(image).png", mimeType: "image/png")
 
       return multipartFormData
 
@@ -258,7 +273,7 @@ enum KKRouter: URLRequestConvertible {
         request = try JSONEncoding.default.encode(request)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-      case .postFeed:
+      case .postFeed, .postSignUp:
         request.setValue("multipart/form-data", forHTTPHeaderField: "Content-Type")
 
       default:

--- a/KnockKnock-iOS/Repository/Account/AccountManager.swift
+++ b/KnockKnock-iOS/Repository/Account/AccountManager.swift
@@ -5,7 +5,7 @@
 //  Created by Daye on 2022/11/01.
 //
 
-import Foundation
+import UIKit
 
 protocol AccountManagerProtocol {
   func signIn(
@@ -13,12 +13,7 @@ protocol AccountManagerProtocol {
     socialType: SocialType,
     completionHandler: @escaping (AccountResponse, SignInInfo) -> Void
   )
-  func register(
-    signInInfo: SignInInfo,
-    nickname: String,
-    image: String,
-    completionHandler: @escaping (AccountResponse) -> Void
-  )
+  func register(registerInfo: RegisterInfo, completionHandler: @escaping (AccountResponse) -> Void)
   func signOut(completionHandler: @escaping (Bool) -> Void)
   func withdraw(completionHandler: @escaping (Bool) -> Void)
 }
@@ -27,23 +22,15 @@ final class AccountManager: AccountManagerProtocol {
 
   /// 회원가입
   func register(
-    signInInfo: SignInInfo,
-    nickname: String,
-    image: String,
+    registerInfo: RegisterInfo,
     completionHandler: @escaping (AccountResponse) -> Void
   ) {
-    let parameters = [
-      "socialUuid": signInInfo.socialUuid,
-      "socialType": signInInfo.socialType,
-      "nickname": nickname,
-      "image": image
-    ]
 
     KKNetworkManager
       .shared
       .request(
         object: ApiResponseDTO<AccountResponse>.self,
-        router: KKRouter.postSignUp(userInfo: parameters),
+        router: KKRouter.postSignUp(userInfo: registerInfo),
         success: { response in
           guard let data = response.data else {
             // no data error

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingInteractor.swift
@@ -14,7 +14,7 @@ protocol ProfileSettingInteractorProtocol {
 
   var signInInfo: SignInInfo? { get set }
 
-  func requestSignUp(nickname: String, image: String)
+  func requestSignUp(nickname: String, image: UIImage)
 
   func navigateToMyView()
 }
@@ -35,18 +35,20 @@ final class ProfileSettingInteractor: ProfileSettingInteractorProtocol {
 
   func requestSignUp(
     nickname: String,
-    image: String
+    image: UIImage
   ) {
-    if let signInInfo = signInInfo {
+    guard let signInInfo = signInInfo else { return }
+    let registerInfo = RegisterInfo(socialUuid: signInInfo.socialUuid,
+                                    socialType: signInInfo.socialType,
+                                    nickname: nickname,
+                                    image: image)
+
       self.worker?.requestRegister(
-        signInInfo: signInInfo,
-        nickname: nickname,
-        image: image,
+        registerInfo: registerInfo,
         completionHandler: { response in
           self.saveUserInfo(response: response)
         }
       )
-    }
   }
 
   func saveUserInfo(response: AccountResponse) {

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
@@ -58,8 +58,57 @@ final class ProfileSettingViewController: BaseViewController<ProfileSettingView>
         for: .touchUpInside
       )
     }
-
+    self.addKeyboardNotification()
     self.hideKeyboardWhenTappedAround()
+  }
+
+  // MARK: - Keyboard Show & Hide
+
+  private func addKeyboardNotification() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(keyboardWillShow(_:)),
+      name: UIResponder.keyboardWillShowNotification,
+      object: nil
+    )
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(keyboardWillHide(_:)),
+      name: UIResponder.keyboardWillHideNotification,
+      object: nil
+    )
+  }
+
+  @objc private func keyboardWillShow(_ notification: Notification) {
+    self.setContainerViewConstant(notification: notification, isAppearing: true)
+  }
+
+  @objc private func keyboardWillHide(_ notification: Notification) {
+    self.setContainerViewConstant(notification: notification, isAppearing: false)
+  }
+
+  private func setContainerViewConstant(notification: Notification, isAppearing: Bool) {
+    let userInfo = notification.userInfo
+
+    if let keyboardFrame = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+      let keyboardSize = keyboardFrame.cgRectValue
+      let keyboardHeight = keyboardSize.height
+
+      guard let animationDurationValue = userInfo?[
+        UIResponder
+          .keyboardAnimationDurationUserInfoKey
+      ] as? NSNumber else { return }
+
+      let viewHeightConstant = isAppearing ? (keyboardHeight + 30) : 50
+
+      UIView.animate(withDuration: animationDurationValue.doubleValue) {
+        self.containerView.confirmButton.snp.updateConstraints {
+          $0.top.equalTo(self.containerView.safeAreaLayoutGuide.snp.bottom).inset(viewHeightConstant)
+        }
+        self.containerView.layoutIfNeeded()
+      }
+    }
   }
 
   // MARK: - TextField Actions

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
@@ -67,7 +67,7 @@ final class ProfileSettingViewController: BaseViewController<ProfileSettingView>
   // MARK: - Button Actions
 
   @objc private func backButtonDidTap(_ sender: UIButton) {
-    self.navigationController?.popViewController(animated: true)
+    self.interactor?.navigateToMyView()
   }
 
   @objc private func confirmButtonDidTap(_ sender: UIButton) {

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
@@ -96,7 +96,7 @@ extension ProfileSettingViewController: ProfileSettingViewProtocol {
 // MARK: - TextField delegate
 
 extension ProfileSettingViewController: UITextFieldDelegate {
-  func textFieldDidEndEditing(_ textField: UITextField) {
+  func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
     if textField.hasText {
       textField.layer.borderColor = UIColor.green50?.cgColor
       self.containerView.confirmButton.backgroundColor = .green50
@@ -106,5 +106,6 @@ extension ProfileSettingViewController: UITextFieldDelegate {
       self.containerView.confirmButton.backgroundColor = .gray40
       self.containerView.confirmButton.isEnabled = false
     }
+    return true
   }
 }

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingViewController.swift
@@ -15,6 +15,11 @@ protocol ProfileSettingViewProtocol: AnyObject {
 
 final class ProfileSettingViewController: BaseViewController<ProfileSettingView> {
 
+  private enum Nickname {
+    static let maxLength = 30
+    static let minLength = 2
+  }
+
   // MARK: - Properties
 
   var interactor: ProfileSettingInteractorProtocol?
@@ -40,11 +45,10 @@ final class ProfileSettingViewController: BaseViewController<ProfileSettingView>
     self.navigationItem.title = "프로필 설정"
 
     self.containerView.nicknameTextField.do {
-      $0.delegate = self
       $0.addTarget(
         self,
-        action: #selector(self.textFieldDidTap(_:)),
-        for: .touchDown
+        action: #selector(self.textFieldDidChange(_:)),
+        for: .allEditingEvents
       )
     }
     self.containerView.confirmButton.do {
@@ -60,8 +64,25 @@ final class ProfileSettingViewController: BaseViewController<ProfileSettingView>
 
   // MARK: - TextField Actions
 
-  @objc private func textFieldDidTap(_ textField: UITextField) {
-    self.containerView.bind(isClicked: true)
+  @objc private func textFieldDidChange(_ textField: UITextField) {
+    guard let text = textField.text else { return }
+
+    if text.count >= Nickname.minLength && text.count < Nickname.maxLength {
+      textField.layer.borderColor = UIColor.green50?.cgColor
+      self.containerView.confirmButton.backgroundColor = .green50
+      self.containerView.confirmButton.isEnabled = true
+    } else {
+      textField.layer.borderColor = UIColor.gray30?.cgColor
+      self.containerView.confirmButton.backgroundColor = .gray40
+      self.containerView.confirmButton.isEnabled = false
+    }
+
+    // 최대 글자 수 초과시 입력 제한
+    if text.count >= Nickname.maxLength {
+      let index = text.index(text.startIndex, offsetBy: Nickname.maxLength)
+      let newString = text[text.startIndex..<index]
+      textField.text = String(newString)
+    }
   }
 
   // MARK: - Button Actions
@@ -91,21 +112,4 @@ final class ProfileSettingViewController: BaseViewController<ProfileSettingView>
 
 extension ProfileSettingViewController: ProfileSettingViewProtocol {
   
-}
-
-// MARK: - TextField delegate
-
-extension ProfileSettingViewController: UITextFieldDelegate {
-  func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-    if textField.hasText {
-      textField.layer.borderColor = UIColor.green50?.cgColor
-      self.containerView.confirmButton.backgroundColor = .green50
-      self.containerView.confirmButton.isEnabled = true
-    } else {
-      textField.layer.borderColor = UIColor.gray30?.cgColor
-      self.containerView.confirmButton.backgroundColor = .gray40
-      self.containerView.confirmButton.isEnabled = false
-    }
-    return true
-  }
 }

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingWorker.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/ProfileSettingWorker.swift
@@ -9,9 +9,7 @@ import UIKit
 
 protocol ProfileSettingWorkerProtocol {
   func requestRegister(
-    signInInfo: SignInInfo,
-    nickname: String,
-    image: String,
+    registerInfo: RegisterInfo,
     completionHandler: @escaping (AccountResponse) -> Void
   )
   func saveUserInfo(response: AccountResponse)
@@ -30,16 +28,12 @@ final class ProfileSettingWorker: ProfileSettingWorkerProtocol {
   }
 
   func requestRegister(
-    signInInfo: SignInInfo,
-    nickname: String,
-    image: String,
+    registerInfo: RegisterInfo,
     completionHandler: @escaping (AccountResponse) -> Void
   ) {
     
     self.accountManager.register(
-      signInInfo: signInInfo,
-      nickname: nickname,
-      image: image,
+      registerInfo: registerInfo,
       completionHandler: { response in
 
         guard let authInfo = response.authInfo else { return }

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/Views/ProfileSettingView.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/Views/ProfileSettingView.swift
@@ -88,6 +88,12 @@ final class ProfileSettingView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 
+  // MARK: - Bind
+
+  func setProfileImage(image: UIImage) {
+    self.profileImageView.image = image
+  }
+
   // MARK: - Configure
   
   private func setupConstraints() {

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/Views/ProfileSettingView.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/Views/ProfileSettingView.swift
@@ -91,11 +91,11 @@ final class ProfileSettingView: UIView {
   // MARK: - Bind
   
   func bind(isClicked: Bool) {
-    if isClicked {
-      self.nicknameTextField.layer.borderColor = KKDS.Color.green50.cgColor
-    } else {
-      self.nicknameTextField.layer.borderColor = KKDS.Color.gray40.cgColor
-    }
+//    if isClicked {
+//      self.nicknameTextField.layer.borderColor = KKDS.Color.green50.cgColor
+//    } else {
+//      self.nicknameTextField.layer.borderColor = KKDS.Color.gray40.cgColor
+//    }
   }
   
   // MARK: - Configure

--- a/KnockKnock-iOS/Scenes/Login/ProfileSetting/Views/ProfileSettingView.swift
+++ b/KnockKnock-iOS/Scenes/Login/ProfileSetting/Views/ProfileSettingView.swift
@@ -76,7 +76,7 @@ final class ProfileSettingView: UIView {
     $0.backgroundColor = .gray40
     $0.isEnabled = false
   }
-  
+
   // MARK: - Initialize
   
   override init(frame: CGRect) {
@@ -87,17 +87,7 @@ final class ProfileSettingView: UIView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-  
-  // MARK: - Bind
-  
-  func bind(isClicked: Bool) {
-//    if isClicked {
-//      self.nicknameTextField.layer.borderColor = KKDS.Color.green50.cgColor
-//    } else {
-//      self.nicknameTextField.layer.borderColor = KKDS.Color.gray40.cgColor
-//    }
-  }
-  
+
   // MARK: - Configure
   
   private func setupConstraints() {
@@ -130,10 +120,10 @@ final class ProfileSettingView: UIView {
       $0.top.equalTo(self.nicknameTextField.snp.bottom).offset(Metric.noticeLabelTopMargin)
       $0.leading.trailing.equalTo(self.safeAreaLayoutGuide).inset(Metric.noticeLabelLeadingMargin)
     }
-    
+
     self.confirmButton.snp.makeConstraints {
       $0.leading.trailing.equalTo(self.safeAreaLayoutGuide).inset(Metric.confirmButtonLeadingMargin)
-      $0.bottom.equalTo(self.safeAreaLayoutGuide).offset(Metric.confirmButtonBottomMargin)
+      $0.top.equalTo(self.safeAreaLayoutGuide.snp.bottom).inset(Metric.confirmButtonHeight)
       $0.height.equalTo(Metric.confirmButtonHeight)
     }
   }


### PR DESCRIPTION
## What is this PR?
- 닉네임 길이 검사(2자 이상 30자 이하)를 수행합니다.
- 프로필 사진을 선택할 수 있습니다.

## Changes
- `ImagePicker`를 이용해 프로필 사진을 갤러리에서 불러와 적용할 수 있도록 하였습니다.
- 닉네임의 길이가 2자~30자 이내에 있을 때에만 완료 버튼이 활성화 되도록 하였습니다.
- 키보드가 활성화 되면 완료버튼이 키보드 위로 올라오도록 하였습니다.

## Test Checklist
- 닉네임 중복 검사 기능의 경우 api가 아직 배포 이전이어서 #124 에서 추후 추가 될 예정입니다.