### PR TITLE
[REFACTOR] 피드 리스트 좋아요 이벤트 발생 시 좋아요 상태 업데이트 로직 수정

### DIFF
--- a/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk",
       "state" : {
-        "revision" : "8a68442660d411031888e6e42c4f628933f62401",
-        "version" : "2.11.1"
+        "revision" : "8b968cfd71e3612dd43892910f8f8b8ca69cd51b",
+        "version" : "2.11.3"
       }
     },
     {

--- a/KnockKnock-iOS/Repository/CommentRepository.swift
+++ b/KnockKnock-iOS/Repository/CommentRepository.swift
@@ -50,11 +50,7 @@ final class CommentRepository: CommentRepositoryProtocol {
           object: ApiResponseDTO<Bool>.self,
           router: KKRouter.postAddComment(comment: parameters),
           success: { response in
-            guard let data = response.data else {
-              // no data error
-              return
-            }
-            completionHandler(data)
+            completionHandler(response.code == 200)
           },
           failure: { error in
             print(error)
@@ -77,11 +73,7 @@ final class CommentRepository: CommentRepositoryProtocol {
         object: ApiResponseDTO<Bool>.self,
         router: KKRouter.deleteComment(id: commentId),
         success: { response in
-          guard let data = response.data else {
-            // no data error
-            return
-          }
-          completionHandler(data)
+          completionHandler(response.code == 200)
         }, failure: { error in
           print(error)
         }

--- a/KnockKnock-iOS/Repository/FeedRepository.swift
+++ b/KnockKnock-iOS/Repository/FeedRepository.swift
@@ -125,11 +125,11 @@ final class FeedRepository: FeedRepositoryProtocol {
         object: ApiResponseDTO<Bool>.self,
         router: KKRouter.deleteFeed(id: feedId),
         success: { response in
-          guard let data = response.data else {
-            // no data error
-            return
+          if response.code == 200 {
+            completionHandler(true)
+          } else {
+            completionHandler(false)
           }
-          completionHandler(data)
         }, failure: { error in
           print(error)
         }

--- a/KnockKnock-iOS/Repository/FeedRepository.swift
+++ b/KnockKnock-iOS/Repository/FeedRepository.swift
@@ -31,7 +31,10 @@ final class FeedRepository: FeedRepositoryProtocol {
 
   // MARK: - Feed main APIs
 
-  func requestChallengeTitles(completionHandler: @escaping ([ChallengeTitle]) -> Void) {
+  func requestChallengeTitles(
+    completionHandler: @escaping ([ChallengeTitle]) -> Void
+  ) {
+
     KKNetworkManager
       .shared
       .request(
@@ -85,7 +88,9 @@ final class FeedRepository: FeedRepositoryProtocol {
     pageSize: Int,
     feedId: Int,
     challengeId: Int,
-    completionHandler: @escaping (FeedList) -> Void) {
+    completionHandler: @escaping (FeedList) -> Void
+  ) {
+
       KKNetworkManager
         .shared
         .request(
@@ -113,6 +118,7 @@ final class FeedRepository: FeedRepositoryProtocol {
     feedId: Int,
     completionHandler: @escaping (Bool) -> Void
   ) {
+
     KKNetworkManager
       .shared
       .request(
@@ -136,6 +142,7 @@ final class FeedRepository: FeedRepositoryProtocol {
     feedId: Int,
     completionHandler: @escaping (FeedDetail) -> Void
   ) {
+    
     KKNetworkManager
       .shared
       .request(

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListPresenter.swift
@@ -11,6 +11,7 @@ protocol FeedListPresenterProtocol {
   var view: FeedListViewController? { get set }
 
   func presentFetchFeedList(feedList: FeedList)
+  func presentUpdateFeedList(feedList: FeedList, sections: [IndexPath])
   func reloadFeedList()
 }
 
@@ -19,6 +20,17 @@ final class FeedListPresenter: FeedListPresenterProtocol {
 
   func presentFetchFeedList(feedList: FeedList) {
     self.view?.fetchFeedList(feedList: feedList)
+    LoadingIndicator.hideLoading()
+  }
+
+  func presentUpdateFeedList(
+    feedList: FeedList,
+    sections: [IndexPath]
+  ) {
+    self.view?.updateFeedList(
+      feedList: feedList,
+      sections: sections
+    )
     LoadingIndicator.hideLoading()
   }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
@@ -14,6 +14,7 @@ protocol FeedListViewProtocol: AnyObject {
   var interactor: FeedListInteractorProtocol? { get set }
   
   func fetchFeedList(feedList: FeedList)
+  func updateFeedList(feedList: FeedList, sections: [IndexPath])
   func reloadFeedList()
 }
 
@@ -24,11 +25,7 @@ final class FeedListViewController: BaseViewController<FeedListView> {
   var interactor: FeedListInteractorProtocol?
 
   private var isNext: Bool = true
-  private var feedListPost: [FeedList.Post] = [] {
-    didSet {
-      self.containerView.feedListCollectionView.reloadData()
-    }
-  }
+  private var feedListPost: [FeedList.Post] = []
 
   private var currentPage: Int = 1
   private var pageSize: Int = 5
@@ -44,8 +41,6 @@ final class FeedListViewController: BaseViewController<FeedListView> {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-
-    self.interactor?.setNotification()
 
     self.interactor?.fetchFeedList(
       currentPage: self.currentPage,
@@ -124,11 +119,7 @@ final class FeedListViewController: BaseViewController<FeedListView> {
   }
 
   private func likeButtonDidTap(sender: UIButton) {
-    if sender.isSelected {
-      self.interactor?.requestLikeCancel(feedId: sender.tag)
-    } else {
-      self.interactor?.requestLike(feedId: sender.tag)
-    }
+    self.interactor?.requestLike(feedId: sender.tag)
   }
 }
 
@@ -267,11 +258,38 @@ extension FeedListViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - Feed List View Protocol
 
 extension FeedListViewController: FeedListViewProtocol {
+
+  /// 피드 최초 요청 이벤트
+  ///
+  /// - Parameters:
+  ///   - feedList: 최초 요청한 피드리스트
   func fetchFeedList(feedList: FeedList) {
     self.isNext = feedList.isNext
     self.feedListPost = feedList.feeds
+
+    DispatchQueue.main.async {
+      self.containerView.feedListCollectionView.reloadData()
+    }
   }
 
+  /// 피드 업데이트 이벤트
+  ///
+  /// - Parameters:
+  ///   - feedList: 업데이트 되어진 피드 리스트
+  ///   - sections: 업데이트 된 피드의 Sections
+  func updateFeedList(feedList: FeedList, sections: [IndexPath]) {
+    self.feedListPost = feedList.feeds
+
+    DispatchQueue.main.async {
+      UIView.performWithoutAnimation {
+        sections.forEach { indexPath in
+          self.containerView.feedListCollectionView.reloadSections(IndexSet(integer: indexPath.section))
+        }
+      }
+    }
+  }
+
+  /// 로그인/로그아웃 시 피드 데이터 re-fatch & reload
   func reloadFeedList() {
     self.interactor?.fetchFeedList(
       currentPage: self.currentPage,

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -16,12 +16,27 @@ protocol FeedListWorkerProtocol {
     completionHandler: @escaping (FeedList) -> Void
   )
   func requestDeleteFeed(feedId: Int, completionHandler: @escaping (Bool) -> Void)
-  func requestLike(feedId: Int, completionHandler: @escaping (Bool) -> Void)
-  func requestLikeCancel(feedId: Int, completionHandler: @escaping (Bool) -> Void)
+  func requestLike(isLike: Bool, feedId: Int, completionHandler: @escaping (Bool) -> Void)
   func checkTokenExisted() -> Bool
+
+  func checkCurrentLikeState(
+    feedList: [FeedList.Post],
+    feedId: Int
+  ) -> Bool
+
+  func changedLikeSections(
+    feeds: [FeedList.Post],
+    id: Int
+  ) -> [Int]
+
+  func convertLikeFeed(
+    feeds: FeedList,
+    id: Int
+  ) -> FeedList
 }
 
 final class FeedListWorker: FeedListWorkerProtocol {
+  typealias OnCompletionHandler = (Bool) -> Void
   
   private let feedRepository: FeedRepositoryProtocol
   private let likeRepository: LikeRepositoryProtocol
@@ -50,8 +65,7 @@ final class FeedListWorker: FeedListWorkerProtocol {
   }
   
   func checkTokenExisted() -> Bool {
-    let isExisted = self.userDataManager.checkTokenIsExisted()
-    return isExisted
+    return self.userDataManager.checkTokenIsExisted()
   }
   
   func fetchFeedList(
@@ -61,8 +75,7 @@ final class FeedListWorker: FeedListWorkerProtocol {
     challengeId: Int,
     completionHandler: @escaping (FeedList) -> Void
   ) {
-    LoadingIndicator.showLoading()
-    feedRepository.requestFeedList(
+    self.feedRepository.requestFeedList(
       currentPage: currentPage,
       pageSize: count,
       feedId: feedId,
@@ -74,26 +87,87 @@ final class FeedListWorker: FeedListWorkerProtocol {
   }
   
   func requestLike(
+    isLike: Bool,
     feedId: Int,
-    completionHandler: @escaping (Bool) -> Void
+    completionHandler: @escaping OnCompletionHandler
   ) {
-    self.likeRepository.requestLike(
-      id: feedId,
-      completionHandler: { result in
-        completionHandler(result)
-      }
-    )
+    if !isLike {
+      self.likeRepository.requestLike(
+        id: feedId,
+        completionHandler: { result in
+          completionHandler(result)
+        }
+      )
+    } else {
+      self.likeRepository.requestLikeCancel(
+        id: feedId,
+        completionHandler: { result in
+          completionHandler(result)
+        }
+      )
+    }
   }
-  
-  func requestLikeCancel(
-    feedId: Int,
-    completionHandler: @escaping (Bool) -> Void
-  ) {
-    self.likeRepository.requestLikeCancel(
-      id: feedId,
-      completionHandler: { result in
-        completionHandler(result)
-      }
-    )
+
+  func changedLikeSections(
+    feeds: [FeedList.Post],
+    id: Int
+  ) -> [Int] {
+
+    var sections: [Int] = []
+
+    for (index, feed) in feeds.enumerated() where feed.id == id {
+      sections.append(index)
+    }
+
+    return sections
+  }
+
+  func convertLikeFeed(
+    feeds: FeedList,
+    id: Int
+  ) -> FeedList {
+    var feeds = feeds
+
+    self.changedLikeSections(feeds: feeds.feeds, id: id).forEach {
+      self.setToggleLike(feed: &feeds.feeds[$0])
+      self.setLikeCount(feed: &feeds.feeds[$0])
+    }
+
+    return feeds
+  }
+
+  func checkCurrentLikeState(
+    feedList: [FeedList.Post],
+    feedId: Int
+  ) -> Bool {
+    var isLike = true
+
+    for (index, feed) in feedList.enumerated() where feed.id == feedId {
+      isLike = feedList[index].isLike
+    }
+    return isLike
+  }
+}
+
+// MARK: - Inner Action
+extension FeedListWorker {
+
+  private func setToggleLike(feed: inout FeedList.Post) {
+    feed.isLike.toggle()
+  }
+
+  private func setLikeCount(feed: inout FeedList.Post) {
+    let title = feed.blogLikeCount.filter { $0.isNumber }
+
+    let numberFormatter = NumberFormatter().then {
+      $0.numberStyle = .decimal
+    }
+
+    guard let titleToInt = Int(title) else { return }
+
+    let number = feed.isLike ? (titleToInt + 1) : (titleToInt - 1)
+    let newTitle = numberFormatter.string(from: NSNumber(value: number)) ?? ""
+
+    feed.blogLikeCount = " \(newTitle)"
   }
 }


### PR DESCRIPTION
## What is this PR?
- 화면에 표시 된 게시글 리스트에서 좋아요 이벤트가 발생한 게시글을 찾아 상태를 업데이트 하는 로직을 리팩토링하였습니다.
- 삭제 이벤트 발생 시에도 동일하게 적용하였습니다.

## Changes
- 좋아요 이벤트가 발생할 때마다 전체 데이터를 리로드하는 방식으로 구성 된 기존 코드에서 해당 섹션만 찾아 업데이트 하도록 변경하였습니다.
- 테스트 코드 작성이 용이하도록 전반적인 코드가 수정되었습니다.
- 삭제 이벤트 또한 전체 리스트에서 해당 게시글을 찾아 모두 삭제되도록 수정하였습니다.

## Test Checklist
- none.