### PR TITLE
[FEAT]  리스트/상세에서 게시글 삭제 시 피드 메인에도 삭제 반영

### DIFF
--- a/KnockKnock-iOS/Entity/Feed/FeedList.swift
+++ b/KnockKnock-iOS/Entity/Feed/FeedList.swift
@@ -25,21 +25,6 @@ struct FeedList: Decodable {
     let blogImages: [Image]
     let isWriter: Bool
 
-    mutating func setLikeCount() {
-      let title = blogLikeCount.filter({ $0.isNumber })
-
-      let numberFormatter = NumberFormatter().then {
-        $0.numberStyle = .decimal
-      }
-
-      guard let titleToInt = Int(title) else { return }
-
-      let number = isLike ? (titleToInt + 1) : (titleToInt - 1)
-      let newTitle = numberFormatter.string(from: NSNumber(value: number)) ?? ""
-
-      blogLikeCount = " \(newTitle)"
-    }
-
     func toShare() -> FeedShare? {
       
       return FeedShare(
@@ -57,15 +42,4 @@ struct FeedList: Decodable {
     let id: Int
     let fileUrl: String
   }
-//
-//  mutating func toggleIsLike(feedId: Int) {
-//    let indexArray = feeds.enumerated().filter {
-//      $0.1.id == feedId
-//    }.map { $0.0 }
-//
-//    indexArray.forEach {
-//      feeds[$0].isLike.toggle()
-//      feeds[$0].setLikeCount()
-//    }
-//  }
 }

--- a/KnockKnock-iOS/Entity/Feed/FeedList.swift
+++ b/KnockKnock-iOS/Entity/Feed/FeedList.swift
@@ -57,16 +57,15 @@ struct FeedList: Decodable {
     let id: Int
     let fileUrl: String
   }
-
-  mutating func toggleIsLike(feedId: Int) {
-    let indexArray = feeds.enumerated().filter {
-      $0.1.id == feedId
-    }.map { $0.0 }
-
-    indexArray.forEach {
-      feeds[$0].isLike.toggle()
-      feeds[$0].setLikeCount()
-    }
-  }
-
+//
+//  mutating func toggleIsLike(feedId: Int) {
+//    let indexArray = feeds.enumerated().filter {
+//      $0.1.id == feedId
+//    }.map { $0.0 }
+//
+//    indexArray.forEach {
+//      feeds[$0].isLike.toggle()
+//      feeds[$0].setLikeCount()
+//    }
+//  }
 }

--- a/KnockKnock-iOS/Entity/Feed/FeedMain.swift
+++ b/KnockKnock-iOS/Entity/Feed/FeedMain.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 struct FeedMain: Decodable {
-  let isNext: Bool
+  var isNext: Bool
   let total: Int
-  let feeds: [Post]
+  var feeds: [Post]
 
   struct Post: Decodable {
     let id: Int

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -227,7 +227,7 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
 
   func showAlertView(
     message: String,
-    confirmAction: (()-> Void)?
+    confirmAction: (() -> Void)?
   ) {
     self.router?.showAlertView(
       message: message,

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
@@ -21,7 +21,7 @@ protocol FeedDetailRouterProtocol {
   )
   func showAlertView(
     message: String,
-    confirmAction: (()-> Void)?
+    confirmAction: (() -> Void)?
   )
 }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
@@ -15,7 +15,14 @@ protocol FeedDetailRouterProtocol {
   func navigateToLikeDetail(like: [Like.Info])
   func navigateToLoginView()
   func navigateToFeedList()
-  func presentBottomSheetView(isMyPost: Bool, deleteAction: (() -> Void)?)
+  func presentBottomSheetView(
+    isMyPost: Bool,
+    deleteAction: (() -> Void)?
+  )
+  func showAlertView(
+    message: String,
+    confirmAction: (()-> Void)?
+  )
 }
 
 final class FeedDetailRouter: FeedDetailRouterProtocol {

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -65,7 +65,7 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
       completionHandler: { isSuccess in
 
         if isSuccess {
-          self.postNotification()
+          self.postResfreshNotificationEvent(feedId: feedId)
         }
         completionHandler(isSuccess)
       }
@@ -198,7 +198,7 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
 // MAKR: - Inner Actions
 
 extension FeedDetailWorker {
-  private func postNotification() {
+  private func postResfreshNotificationEvent(feedId: Int) {
     NotificationCenter.default.post(
       name: .feedListRefreshAfterDelete,
       object: feedId

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -65,11 +65,12 @@ final class FeedListWorker: FeedListWorkerProtocol {
   
   func requestDeleteFeed(
     feedId: Int,
-    completionHandler: @escaping (Bool) -> Void
+    completionHandler: @escaping OnCompletionHandler
   ) {
     self.feedRepository.requestDeleteFeed(
       feedId: feedId,
       completionHandler: { isSuccess in
+        self.postResfreshNotificationEvent(feedId: feedId)
         completionHandler(isSuccess)
       }
     )
@@ -199,5 +200,12 @@ extension FeedListWorker {
     let newTitle = numberFormatter.string(from: NSNumber(value: number)) ?? ""
     
     feed.blogLikeCount = " \(newTitle)"
+  }
+
+  private func postResfreshNotificationEvent(feedId: Int) {
+    NotificationCenter.default.post(
+      name: .feedMainRefreshAfterDelete,
+      object: feedId
+    )
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -25,20 +25,36 @@ final class FeedMainInteractor: FeedMainInteractorProtocol {
   var presenter: FeedMainPresenterProtocol?
   var worker: FeedMainWorkerProtocol?
 
+  private var feedData: FeedMain?
+
   func saveSearchKeyword(searchKeyword: [SearchKeyword]) {
     self.worker?.saveSearchKeyword(searchKeyword: searchKeyword)
   }
 
-  func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int) {
+  func fetchFeedMain(
+    currentPage: Int,
+    pageSize: Int,
+    challengeId: Int
+  ) {
     LoadingIndicator.showLoading()
     
     self.worker?.fetchFeedMain(
       currentPage: currentPage,
       pageSize: pageSize,
       challengeId: challengeId,
-      completionHandler: { [weak self] feed in
-      self?.presenter?.presentFeedMain(feed: feed)
-    })
+      completionHandler: { [weak self] data in
+
+        if currentPage == 1 {
+          self?.feedData = data
+        } else {
+          self?.feedData?.feeds += data.feeds
+          self?.feedData?.isNext = data.isNext
+        }
+
+        guard let feedData = self?.feedData else { return }
+        self?.presenter?.presentFeedMain(feed: feedData)
+      }
+    )
   }
 
   func fetchChallengeTitles() {

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -27,6 +27,14 @@ final class FeedMainInteractor: FeedMainInteractorProtocol {
 
   private var feedData: FeedMain?
 
+  // MARK: - Initialize
+
+  init() {
+    self.setNotification()
+  }
+
+  // MARK: - Business Logic
+
   func saveSearchKeyword(searchKeyword: [SearchKeyword]) {
     self.worker?.saveSearchKeyword(searchKeyword: searchKeyword)
   }
@@ -77,5 +85,36 @@ final class FeedMainInteractor: FeedMainInteractorProtocol {
       }
     }
     presenter?.presentGetChallengeTitles(challengeTitle: challengeTitles, index: selectedIndex)
+  }
+}
+
+extension FeedMainInteractor {
+
+  /// 피드 상세에서 발생한 삭제 이벤트 반영
+  @objc
+  private func deleteNotificationEvent(_ notification: Notification) {
+    guard let feedId = notification.object as? Int else { return }
+
+    guard let feedData = self.feedData else { return }
+    guard !feedData.feeds.isEmpty else { return }
+
+    // 삭제 요청한 피드의 index
+    guard let index = self.feedData?.feeds.firstIndex(where: { feedId == $0.id }) else { return }
+
+    self.feedData?.feeds.remove(at: index)
+
+    guard let feedData = self.feedData else { return }
+    self.presenter?.presentFeedMain(feed: feedData)
+  }
+
+  // MARK: - Notification Center
+
+  private func setNotification() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.deleteNotificationEvent(_:)),
+      name: .feedMainRefreshAfterDelete,
+      object: nil
+    )
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -29,15 +29,14 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
   var interactor: FeedMainInteractorProtocol?
   var router: FeedMainRouterProtocol?
   
-  private var feedMain: FeedMain?
-
-  private var feedMainPost: [FeedMain.Post] = [] {
+  private var feedMain: FeedMain? {
     didSet {
-      DispatchQueue.main.async {
-        self.containerView.feedCollectionView.reloadData()
-      }
+      guard let feedPosts = feedMain?.feeds else { return }
+      self.feedMainPost = feedPosts
     }
   }
+  private var feedMainPost: [FeedMain.Post] = []
+
   private var challengeTitles: [ChallengeTitle] = []
   private var searchKeyword: [SearchKeyword] = []
   
@@ -121,7 +120,10 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
 extension FeedMainViewController: FeedMainViewProtocol {
   func fetchFeedMain(feed: FeedMain) {
     self.feedMain = feed
-    self.feedMainPost += feedMain?.feeds ?? []
+
+    DispatchQueue.main.async {
+      self.containerView.feedCollectionView.reloadData()
+    }
   }
 
   func fetchSearchLog(searchKeyword: [SearchKeyword]) {
@@ -140,7 +142,8 @@ extension FeedMainViewController: FeedMainViewProtocol {
         self.containerView.tagCollectionView.scrollToItem(
           at: index,
           at: .centeredHorizontally,
-          animated: false)
+          animated: false
+        )
       }
     } else {
       self.containerView.tagCollectionView.reloadData()
@@ -224,9 +227,9 @@ extension FeedMainViewController: UICollectionViewDataSource {
     )
 
     guard let feedMain = self.feedMain else {
-      return UICollectionReusableView()
+      return footer
     }
-    
+
     footer.viewMoreButton.isHidden = !feedMain.isNext
     footer.viewMoreButton.addTarget(
       self,

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -40,10 +40,9 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
   }
   private var challengeTitles: [ChallengeTitle] = []
   private var searchKeyword: [SearchKeyword] = []
-  private var popularPost: [String] = []
   
   private var currentPage = 1
-  private let pageSize = 9 // pageSize 논의 필요
+  private let pageSize = 9
 
   private var challengeId = 0
 
@@ -224,14 +223,11 @@ extension FeedMainViewController: UICollectionViewDataSource {
       for: indexPath
     )
 
-    if let feedMain = self.feedMain {
-      if !feedMain.isNext {
-        footer.viewMoreButton.isHidden = true
-      } else {
-        footer.viewMoreButton.isHidden = false
-      }
+    guard let feedMain = self.feedMain else {
+      return UICollectionReusableView()
     }
     
+    footer.viewMoreButton.isHidden = !feedMain.isNext
     footer.viewMoreButton.addTarget(
       self,
       action: #selector(self.didTapViewMoreButton(_:)),

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -29,23 +29,23 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
   var interactor: FeedMainInteractorProtocol?
   var router: FeedMainRouterProtocol?
   
-  var feedMain: FeedMain?
+  private var feedMain: FeedMain?
 
-  var feedMainPost: [FeedMain.Post] = [] {
+  private var feedMainPost: [FeedMain.Post] = [] {
     didSet {
       DispatchQueue.main.async {
         self.containerView.feedCollectionView.reloadData()
       }
     }
   }
-  var challengeTitles: [ChallengeTitle] = []
-  var searchKeyword: [SearchKeyword] = []
-  var popularPost: [String] = []
+  private var challengeTitles: [ChallengeTitle] = []
+  private var searchKeyword: [SearchKeyword] = []
+  private var popularPost: [String] = []
   
-  var currentPage = 1
-  let pageSize = 9 // pageSize 논의 필요
+  private var currentPage = 1
+  private let pageSize = 9 // pageSize 논의 필요
 
-  var challengeId = 0
+  private var challengeId = 0
 
   // MARK: - UIs
 


### PR DESCRIPTION
## What is this PR?
- 피드 리스트와 피드 상세 화면에서 게시글 삭제 후 화면을 빠져나왔을 때, 리스트/메인 화면에도 삭제 상태가 반영되도록 하였습니다.

## Changes
- NotificationCenter를 이용하여 삭제 이벤트를 전달하고, 데이터 상태를 업데이트합니다.

## Test Checklist
- none.