### PR TITLE
[FEAT] 챌린지 정렬(인기순/최신순)

### DIFF
--- a/KnockKnock-iOS.xcodeproj/project.pbxproj
+++ b/KnockKnock-iOS.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		61A5EA2328B3B71300A0214D /* StoreListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5EA2228B3B71300A0214D /* StoreListView.swift */; };
 		61A5EA2528B3B72100A0214D /* StoreListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5EA2428B3B72100A0214D /* StoreListViewController.swift */; };
 		61A5EA2728B3BEDC00A0214D /* StoreListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5EA2628B3BEDC00A0214D /* StoreListCell.swift */; };
+		61A6B7272989174B002A1C57 /* ChallengeSortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A6B7262989174B002A1C57 /* ChallengeSortType.swift */; };
 		61A730DF28ED4EBA00C6BD98 /* MyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A730DE28ED4EBA00C6BD98 /* MyViewController.swift */; };
 		61A730E228ED4ECD00C6BD98 /* MyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A730E128ED4ECD00C6BD98 /* MyView.swift */; };
 		61A8DC44287E8783000512EC /* UIDevice+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A8DC43287E8783000512EC /* UIDevice+Ext.swift */; };
@@ -418,6 +419,7 @@
 		61A5EA2228B3B71300A0214D /* StoreListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListView.swift; sourceTree = "<group>"; };
 		61A5EA2428B3B72100A0214D /* StoreListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListViewController.swift; sourceTree = "<group>"; };
 		61A5EA2628B3BEDC00A0214D /* StoreListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListCell.swift; sourceTree = "<group>"; };
+		61A6B7262989174B002A1C57 /* ChallengeSortType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeSortType.swift; sourceTree = "<group>"; };
 		61A730DE28ED4EBA00C6BD98 /* MyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyViewController.swift; sourceTree = "<group>"; };
 		61A730E128ED4ECD00C6BD98 /* MyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyView.swift; sourceTree = "<group>"; };
 		61A8DC43287E8783000512EC /* UIDevice+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Ext.swift"; sourceTree = "<group>"; };
@@ -1219,6 +1221,7 @@
 				616524C0297ECEE9009610C3 /* KakaoShareErrorType.swift */,
 				6128A4C0297F7B02005E36F3 /* ShareURL.swift */,
 				61CCF3FA2984D7F000FBAB07 /* SharQueryItemType.swift */,
+				61A6B7262989174B002A1C57 /* ChallengeSortType.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1656,6 +1659,7 @@
 				6143294D285DD2A0008BDCC9 /* FeedMainFooterCollectionReusableView.swift in Sources */,
 				611BD4A527E3080B007D5C79 /* FeedWriteView.swift in Sources */,
 				61DEFE8E2941AF9000ABC13E /* AlertViewController.swift in Sources */,
+				61A6B7272989174B002A1C57 /* ChallengeSortType.swift in Sources */,
 				618D8B6028BDF6C900828794 /* SearchTap.swift in Sources */,
 				201077F827D3BF4B00280991 /* Array+Ext.swift in Sources */,
 				6128A4C1297F7B02005E36F3 /* ShareURL.swift in Sources */,

--- a/KnockKnock-iOS/Entity/Challenge.swift
+++ b/KnockKnock-iOS/Entity/Challenge.swift
@@ -20,7 +20,6 @@ struct Challenge: Decodable {
 
   struct Participant: Decodable {
     let id: Int
-    let nickname: String
     let image: String?
   }
 }
@@ -32,7 +31,6 @@ struct ChallengeDetail: Decodable {
 
   struct Participant: Decodable {
     let id: Int
-    let nickname: String
     let image: String?
   }
 

--- a/KnockKnock-iOS/Enum/BottomSheetOption.swift
+++ b/KnockKnock-iOS/Enum/BottomSheetOption.swift
@@ -13,6 +13,8 @@ enum BottomSheetOption: String {
   case postReport = "신고하기"
   case postShare = "공유하기"
   case postHide = "숨기기"
+  case challengeNew = "최신순"
+  case challengePopular = "인기순"
 }
 
 enum BottomSheetType: CGFloat {

--- a/KnockKnock-iOS/Enum/ChallengeSortType.swift
+++ b/KnockKnock-iOS/Enum/ChallengeSortType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum ChallengeSortType {
-  case new
-  case popular
+enum ChallengeSortType: String {
+  case new = "BRAND_NEW"
+  case popular = "POPULAR"
 }

--- a/KnockKnock-iOS/Enum/ChallengeSortType.swift
+++ b/KnockKnock-iOS/Enum/ChallengeSortType.swift
@@ -1,0 +1,13 @@
+//
+//  ChallengeSort.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2023/01/31.
+//
+
+import Foundation
+
+enum ChallengeSortType {
+  case new
+  case popular
+}

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIImage+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIImage+Ext.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 extension UIImage {
-  func resize(newWidth: CGFloat) async -> UIImage {
-    let scale = newWidth / self.size.width
-    let newHeight = self.size.height * scale
+  /// 이미지 리사이징(정방형)
+  func resizeSquareImage(newWidth: CGFloat) async -> UIImage {
+    let newHeight = newWidth
 
     let size = CGSize(width: newWidth, height: newHeight)
     let render = UIGraphicsImageRenderer(size: size)

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIImageView+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIImageView+Ext.swift
@@ -28,7 +28,7 @@ extension UIImageView {
 
       } catch {
 
-        let image = await defaultImage.resize(newWidth: imageWidth ?? self.frame.width)
+        let image = await defaultImage.resizeSquareImage(newWidth: imageWidth ?? self.frame.width)
 
         await MainActor.run {
           self.image = image
@@ -75,7 +75,7 @@ extension UIImageView {
         throw ImageError.loadError
       }
 
-      let resizeImage = await image.resize(newWidth: imageWidth ?? self.frame.width)
+      let resizeImage = await image.resizeSquareImage(newWidth: imageWidth ?? self.frame.width)
 
       return resizeImage
     }

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIImageView+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIImageView+Ext.swift
@@ -15,7 +15,8 @@ extension UIImageView {
 
   func setImageFromStringUrl(
     stringUrl: String?,
-    defaultImage: UIImage
+    defaultImage: UIImage,
+    imageWidth: CGFloat? = nil
   ) {
     Task {
       do {
@@ -26,7 +27,8 @@ extension UIImageView {
         }
 
       } catch {
-        let image = await defaultImage.resize(newWidth: self.frame.width)
+
+        let image = await defaultImage.resize(newWidth: imageWidth ?? self.frame.width)
 
         await MainActor.run {
           self.image = image
@@ -59,7 +61,10 @@ extension UIImageView {
   }
 
   /// 이미지 로드
-  private func loadImage(stringUrl: String?) async throws -> UIImage {
+  private func loadImage(
+    stringUrl: String?,
+    imageWidth: CGFloat? = nil
+  ) async throws -> UIImage {
 
     guard let chacedImage = await self.setCachedImage(stringUrl: stringUrl) else {
 
@@ -70,7 +75,7 @@ extension UIImageView {
         throw ImageError.loadError
       }
 
-      let resizeImage = await image.resize(newWidth: self.frame.width)
+      let resizeImage = await image.resize(newWidth: imageWidth ?? self.frame.width)
 
       return resizeImage
     }

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
@@ -33,14 +33,22 @@ extension UIStackView {
         $0.layer.borderWidth = 1
         $0.layer.borderColor = UIColor.white.cgColor
         $0.backgroundColor = .white
-
-        $0.image = images[index]
-          .flatMap { URL(string: $0) }
-          .flatMap { try? Data(contentsOf: $0) }
-          .flatMap { UIImage(data: $0) }
-        ?? KKDS.Image.ic_person_24
+        $0.clipsToBounds = true
       }
-      addArrangedSubview(imageView)
+
+      Task {
+        do {
+          let profileImage = images[index]
+            .flatMap { URL(string: $0) }
+            .flatMap { try? Data(contentsOf: $0) }
+            .flatMap { UIImage(data: $0) }
+          ?? KKDS.Image.ic_person_24
+
+          imageView.image = await profileImage.resize(newWidth: 24)
+
+          addArrangedSubview(imageView)
+        }
+      }
 
       if index == 2 {
         break

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
@@ -44,7 +44,7 @@ extension UIStackView {
             .flatMap { UIImage(data: $0) }
           ?? KKDS.Image.ic_person_24
 
-          imageView.image = await profileImage.resize(newWidth: 24)
+          imageView.image = await profileImage.resizeSquareImage(newWidth: 24)
 
           addArrangedSubview(imageView)
         }

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
@@ -26,33 +26,29 @@ extension UIStackView {
       images.append(nil)
     }
 
-    Task {
-      do {
-        for index in 0..<images.count {
-          let imageView = UIImageView().then {
-            $0.contentMode = .scaleAspectFill
-            $0.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
-            $0.layer.cornerRadius = $0.frame.width / 2
-            $0.layer.borderWidth = 1
-            $0.layer.borderColor = UIColor.white.cgColor
-            $0.backgroundColor = .white
-            $0.clipsToBounds = true
-          }
+    for index in 0..<images.count {
+      let imageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
+        $0.layer.cornerRadius = $0.frame.width / 2
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = UIColor.white.cgColor
+        $0.backgroundColor = .white
+        $0.clipsToBounds = true
+      }
 
-          let profileImage = images[index]
-            .flatMap { URL(string: $0) }
-            .flatMap { try? Data(contentsOf: $0) }
-            .flatMap { UIImage(data: $0) }
-          ?? KKDS.Image.ic_person_24
+      let profileImage = images[index]
+        .flatMap { URL(string: $0) }
+        .flatMap { try? Data(contentsOf: $0) }
+        .flatMap { UIImage(data: $0) }
+      ?? KKDS.Image.ic_person_24
 
-          imageView.image = await profileImage.resizeSquareImage(newWidth: 24)
+      imageView.image = profileImage.resizeSquareImage(newWidth: 24)
 
-          addArrangedSubview(imageView)
+      addArrangedSubview(imageView)
 
-          if index == 2 {
-            break
-          }
-        }
+      if index == 2 {
+        break
       }
     }
   }

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
@@ -21,23 +21,24 @@ extension UIStackView {
   func addParticipantImageViews(images: [String?]) {
     var images = images
 
+    // 참여자가 없을 경우 디폴트 이미지 1개 내려주기 위해서 nil 삽입
     if images.count == 0 {
-      images.append("")
+      images.append(nil)
     }
 
-    for index in 0..<images.count {
-      let imageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFill
-        $0.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
-        $0.layer.cornerRadius = $0.frame.width / 2
-        $0.layer.borderWidth = 1
-        $0.layer.borderColor = UIColor.white.cgColor
-        $0.backgroundColor = .white
-        $0.clipsToBounds = true
-      }
+    Task {
+      do {
+        for index in 0..<images.count {
+          let imageView = UIImageView().then {
+            $0.contentMode = .scaleAspectFill
+            $0.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
+            $0.layer.cornerRadius = $0.frame.width / 2
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.white.cgColor
+            $0.backgroundColor = .white
+            $0.clipsToBounds = true
+          }
 
-      Task {
-        do {
           let profileImage = images[index]
             .flatMap { URL(string: $0) }
             .flatMap { try? Data(contentsOf: $0) }
@@ -47,11 +48,11 @@ extension UIStackView {
           imageView.image = await profileImage.resizeSquareImage(newWidth: 24)
 
           addArrangedSubview(imageView)
-        }
-      }
 
-      if index == 2 {
-        break
+          if index == 2 {
+            break
+          }
+        }
       }
     }
   }

--- a/KnockKnock-iOS/Network/KKRouter.swift
+++ b/KnockKnock-iOS/Network/KKRouter.swift
@@ -35,7 +35,7 @@ enum KKRouter: URLRequestConvertible {
   case postLogOut
 
   // Challenge
-  case getChallengeResponse
+  case getChallenges(sort: String)
   case getChallengeDetail(id: Int)
 
   // Feed Write, Main
@@ -64,7 +64,7 @@ enum KKRouter: URLRequestConvertible {
 
   var method: HTTPMethod {
     switch self {
-    case .getChallengeResponse,
+    case .getChallenges,
          .getFeedBlogPost,
          .getFeedMain,
          .getFeed,
@@ -108,7 +108,7 @@ enum KKRouter: URLRequestConvertible {
     case .getHotPost: return "home/hot-post"
 
     // Challenge
-    case .getChallengeResponse: return "challenges"
+    case .getChallenges: return "challenges"
     case .getChallengeDetail(let id): return "challenges/\(id)"
 
     // Feed Write, Main
@@ -147,8 +147,8 @@ enum KKRouter: URLRequestConvertible {
     case let .postSocialLogin(signInInfo):
       return signInInfo
 
-//    case let .postSignUp(userInfo):
-//      return userInfo
+    case let .getChallenges(sort):
+      return [ "sort": sort ]
 
     case let .requestShopAddress(query, page, size):
       return [
@@ -176,7 +176,6 @@ enum KKRouter: URLRequestConvertible {
       return comment
 
     case .getChallengeDetail,
-         .getChallengeResponse,
          .getChallengeTitles,
          .getFeed,
          .getPromotions,

--- a/KnockKnock-iOS/Repository/ChellengeRepository.swift
+++ b/KnockKnock-iOS/Repository/ChellengeRepository.swift
@@ -10,17 +10,17 @@ import Foundation
 import Alamofire
 
 protocol ChallengeRepositoryProtocol {
-  func fetchChellenge(completionHandler: @escaping ([Challenge]) -> Void)
+  func fetchChellenge(sortType: String, completionHandler: @escaping ([Challenge]) -> Void)
   func requestChallengeDetail(challengeId: Int, completionHandler: @escaping (ChallengeDetail) -> Void)
 }
 
 final class ChallengeRepository: ChallengeRepositoryProtocol {
-  func fetchChellenge(completionHandler: @escaping ([Challenge]) -> Void) {
+  func fetchChellenge(sortType: String, completionHandler: @escaping ([Challenge]) -> Void) {
 
     KKNetworkManager.shared
       .request(
         object: ApiResponseDTO<[Challenge]>.self,
-        router: KKRouter.getChallengeResponse,
+        router: KKRouter.getChallenges(sort: sortType),
         success: { response in
           
           guard let data = response.data else {

--- a/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetInteractor.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetInteractor.swift
@@ -15,6 +15,7 @@ protocol BottomSheetInteractorProtocol {
 
   func passCityDataToShopSearch(city: String)
   func passCountyDataToShopSearch(county: String)
+  func passChallengeSortType(sortType: ChallengeSortType)
 
   func navigateToShopSearch()
   func dismissView(actionType: BottomSheetOption)
@@ -23,6 +24,7 @@ protocol BottomSheetInteractorProtocol {
 final class BottomSheetInteractor: BottomSheetInteractorProtocol {
   
   weak var districtSelectDelegate: DistrictSelectDelegate?
+  weak var challengeSortDelegate: ChallengeSortDelegate?
 
   var router: BottomSheetRouterProtocol?
   var worker: BottomSheetWorkerProtocol?
@@ -57,6 +59,11 @@ final class BottomSheetInteractor: BottomSheetInteractorProtocol {
   func passCountyDataToShopSearch(county: String) {
     self.districtSelectDelegate?.fetchSelectedCounty(county: county)
     self.navigateToShopSearch()
+  }
+
+  func passChallengeSortType(sortType: ChallengeSortType) {
+    self.challengeSortDelegate?.getSortType(sortType: sortType)
+    self.dismissView(actionType: .challengeNew)
   }
 
   func navigateToShopSearch() {

--- a/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetRouter.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetRouter.swift
@@ -13,6 +13,7 @@ protocol BottomSheetRouterProtocol: AnyObject {
   static func createBottomSheet(
     districtSelectDelegate: DistrictSelectDelegate?,
     districtsType: DistrictsType?,
+    isChallenge: Bool?,
     deleteAction: (() -> Void)?,
     feedData: FeedShare?,
     isMyPost: Bool?
@@ -20,7 +21,7 @@ protocol BottomSheetRouterProtocol: AnyObject {
 
   func navigateToShopSearch()
   func dismissView(action: (() -> Void)?)
-  func presentErrorAlertView(message: String) 
+  func presentErrorAlertView(message: String)
 }
 
 final class BottomSheetRouter: BottomSheetRouterProtocol {
@@ -30,6 +31,7 @@ final class BottomSheetRouter: BottomSheetRouterProtocol {
   static func createBottomSheet(
     districtSelectDelegate: DistrictSelectDelegate? = nil,
     districtsType: DistrictsType? = nil,
+    isChallenge: Bool? = nil,
     deleteAction: (() -> Void)? = nil,
     feedData: FeedShare? = nil,
     isMyPost: Bool? = nil
@@ -50,10 +52,27 @@ final class BottomSheetRouter: BottomSheetRouterProtocol {
     interactor.deleteAction = deleteAction
     interactor.feedData = feedData
 
-    guard let isMyPost = isMyPost else { return view }
-    router.setBottomSheetOptions(isMyPost: isMyPost)
+    if let isMyPost = isMyPost {
+      router.setBottomSheetOptions(isMyPost: isMyPost)
+    }
+    
+    guard isChallenge != nil else { return view }
+    router.setChallengeBottomSheetOption()
 
     return view
+  }
+
+  private func setChallengeBottomSheetOption() {
+    guard let view = self.view as? BottomSheetViewController else { return }
+
+    view.setBottomSheetContents(
+      contents: [
+        BottomSheetOption.challengeNew.rawValue,
+        BottomSheetOption.challengePopular.rawValue
+      ],
+      bottomSheetType: BottomSheetType.small
+    )
+    view.modalPresentationStyle = .overFullScreen
   }
 
   private func setBottomSheetOptions(isMyPost: Bool) {
@@ -75,8 +94,8 @@ final class BottomSheetRouter: BottomSheetRouterProtocol {
       }
     }()
 
-      view.setBottomSheetContents(contents: contents, bottomSheetType: .medium)
-      view.modalPresentationStyle = .overFullScreen
+    view.setBottomSheetContents(contents: contents, bottomSheetType: .medium)
+    view.modalPresentationStyle = .overFullScreen
   }
 
   func presentErrorAlertView(message: String) {

--- a/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetRouter.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetRouter.swift
@@ -13,7 +13,7 @@ protocol BottomSheetRouterProtocol: AnyObject {
   static func createBottomSheet(
     districtSelectDelegate: DistrictSelectDelegate?,
     districtsType: DistrictsType?,
-    isChallenge: Bool?,
+    challengeSortDelegate: ChallengeSortDelegate?,
     deleteAction: (() -> Void)?,
     feedData: FeedShare?,
     isMyPost: Bool?
@@ -31,7 +31,7 @@ final class BottomSheetRouter: BottomSheetRouterProtocol {
   static func createBottomSheet(
     districtSelectDelegate: DistrictSelectDelegate? = nil,
     districtsType: DistrictsType? = nil,
-    isChallenge: Bool? = nil,
+    challengeSortDelegate: ChallengeSortDelegate? = nil,
     deleteAction: (() -> Void)? = nil,
     feedData: FeedShare? = nil,
     isMyPost: Bool? = nil
@@ -56,7 +56,8 @@ final class BottomSheetRouter: BottomSheetRouterProtocol {
       router.setBottomSheetOptions(isMyPost: isMyPost)
     }
     
-    guard isChallenge != nil else { return view }
+    guard challengeSortDelegate != nil else { return view }
+    interactor.challengeSortDelegate = challengeSortDelegate
     router.setChallengeBottomSheetOption()
 
     return view

--- a/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetViewController.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetViewController.swift
@@ -176,6 +176,12 @@ extension BottomSheetViewController: UITableViewDataSource, UITableViewDelegate 
 
       case .postShare:
         self.interactor?.sharePost()
+
+      case .challengeNew:
+        self.interactor?.passChallengeSortType(sortType: ChallengeSortType.new)
+
+      case .challengePopular:
+        self.interactor?.passChallengeSortType(sortType: ChallengeSortType.popular)
         
       default:
         print("Error")

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeInteractor.swift
@@ -11,7 +11,7 @@ protocol ChallengeInteractorProtocol: AnyObject {
   var presenter: ChallengePresenterProtocol? { get set }
   var worker: ChallengeWorkerProtocol? { get set }
   
-  func fetchChallenge(sortType: String)
+  func fetchChallenge(sortType: ChallengeSortType)
   func presentBottomSheet()
   func navigateToChallengeDetail(challengeId: Int)
 }
@@ -24,10 +24,13 @@ final class ChallengeInteractor: ChallengeInteractorProtocol {
   var worker: ChallengeWorkerProtocol?
   var router: ChallengeRouterProtocol?
   
-  func fetchChallenge(sortType: String) {
+  func fetchChallenge(sortType: ChallengeSortType) {
+    LoadingIndicator.showLoading()
+
     self.worker?.fetchChallenge(
       sortType: sortType,
       completionHandler: { [weak self] challenges in
+        
         self?.presenter?.presentFetchChallenge(
           challenges: challenges,
           sortType: sortType
@@ -37,10 +40,16 @@ final class ChallengeInteractor: ChallengeInteractorProtocol {
   }
 
   func presentBottomSheet() {
-    self.router?.presentBottomSheet()
+    self.router?.presentBottomSheet(challengeSortDelegate: self)
   }
 
   func navigateToChallengeDetail(challengeId: Int) {
     self.router?.navigateToChallengeDetail(challengeId: challengeId)
+  }
+}
+
+extension ChallengeInteractor: ChallengeSortDelegate {
+  func getSortType(sortType: ChallengeSortType) {
+    self.fetchChallenge(sortType: sortType)
   }
 }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeInteractor.swift
@@ -11,7 +11,7 @@ protocol ChallengeInteractorProtocol: AnyObject {
   var presenter: ChallengePresenterProtocol? { get set }
   var worker: ChallengeWorkerProtocol? { get set }
   
-  func fetchChallenge()
+  func fetchChallenge(sortType: String)
   func presentBottomSheet()
   func navigateToChallengeDetail(challengeId: Int)
 }
@@ -24,10 +24,16 @@ final class ChallengeInteractor: ChallengeInteractorProtocol {
   var worker: ChallengeWorkerProtocol?
   var router: ChallengeRouterProtocol?
   
-  func fetchChallenge() {
-    self.worker?.fetchChallenge { [weak self] challenges in
-      self?.presenter?.presentFetchChallenge(challenges: challenges)
-    }
+  func fetchChallenge(sortType: String) {
+    self.worker?.fetchChallenge(
+      sortType: sortType,
+      completionHandler: { [weak self] challenges in
+        self?.presenter?.presentFetchChallenge(
+          challenges: challenges,
+          sortType: sortType
+        )
+      }
+    )
   }
 
   func presentBottomSheet() {

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeInteractor.swift
@@ -12,6 +12,8 @@ protocol ChallengeInteractorProtocol: AnyObject {
   var worker: ChallengeWorkerProtocol? { get set }
   
   func fetchChallenge()
+  func presentBottomSheet()
+  func navigateToChallengeDetail(challengeId: Int)
 }
 
 final class ChallengeInteractor: ChallengeInteractorProtocol {
@@ -20,10 +22,19 @@ final class ChallengeInteractor: ChallengeInteractorProtocol {
   
   var presenter: ChallengePresenterProtocol?
   var worker: ChallengeWorkerProtocol?
+  var router: ChallengeRouterProtocol?
   
   func fetchChallenge() {
     self.worker?.fetchChallenge { [weak self] challenges in
       self?.presenter?.presentFetchChallenge(challenges: challenges)
     }
+  }
+
+  func presentBottomSheet() {
+    self.router?.presentBottomSheet()
+  }
+
+  func navigateToChallengeDetail(challengeId: Int) {
+    self.router?.navigateToChallengeDetail(challengeId: challengeId)
   }
 }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengePresenter.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengePresenter.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol ChallengePresenterProtocol: AnyObject {
   var view: ChallengeViewProtocol? { get set }
   
-  func presentFetchChallenge(challenges: [Challenge], sortType: String)
+  func presentFetchChallenge(challenges: [Challenge], sortType: ChallengeSortType)
 }
 
 final class ChallengePresenter: ChallengePresenterProtocol {
@@ -18,11 +18,12 @@ final class ChallengePresenter: ChallengePresenterProtocol {
   
   func presentFetchChallenge(
     challenges: [Challenge],
-    sortType: String
+    sortType: ChallengeSortType
   ) {
     self.view?.fetchChallenges(
       challenges: challenges,
       sortType: sortType
     )
+    LoadingIndicator.hideLoading()
   }
 }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengePresenter.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengePresenter.swift
@@ -10,13 +10,19 @@ import Foundation
 protocol ChallengePresenterProtocol: AnyObject {
   var view: ChallengeViewProtocol? { get set }
   
-  func presentFetchChallenge(challenges: [Challenge])
+  func presentFetchChallenge(challenges: [Challenge], sortType: String)
 }
 
 final class ChallengePresenter: ChallengePresenterProtocol {
   weak var view: ChallengeViewProtocol?
   
-  func presentFetchChallenge(challenges: [Challenge]) {
-    self.view?.fetchChallenges(challenges: challenges)
+  func presentFetchChallenge(
+    challenges: [Challenge],
+    sortType: String
+  ) {
+    self.view?.fetchChallenges(
+      challenges: challenges,
+      sortType: sortType
+    )
   }
 }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeRouter.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeRouter.swift
@@ -8,12 +8,18 @@
 import UIKit
 
 protocol ChallengeRouterProtocol: AnyObject {
+  var view: ChallengeViewProtocol? { get set }
+
   static func createChallenge() -> UIViewController
-  func navigateToChallengeDetail(source: ChallengeViewProtocol, challengeId: Int)
+
+  func navigateToChallengeDetail(challengeId: Int)
+  func presentBottomSheet()
 }
 
 final class ChallengeRouter: ChallengeRouterProtocol {
-  
+
+  weak var view: ChallengeViewProtocol?
+
   static func createChallenge() -> UIViewController {
     let view = ChallengeViewController()
     let interactor = ChallengeInteractor()
@@ -22,24 +28,34 @@ final class ChallengeRouter: ChallengeRouterProtocol {
     let router = ChallengeRouter()
     
     view.interactor = interactor
-    view.router = router
+    interactor.router = router
     interactor.presenter = presenter
     interactor.worker = worker
     presenter.view = view
+    router.view = view
     
     return view
   }
 
-  func navigateToChallengeDetail(
-    source: ChallengeViewProtocol,
-    challengeId: Int
-  ) {
+  func presentBottomSheet() {
+    guard let sourceView = self.view as? UIViewController else { return }
+
+    let bottomSheetViewController = BottomSheetRouter.createBottomSheet(isChallenge: true)
+
+    sourceView.present(
+      bottomSheetViewController,
+      animated: false,
+      completion: nil
+    )
+  }
+
+  func navigateToChallengeDetail(challengeId: Int) {
     let challengeDetailViewController = ChallengeDetailRouter.createChallengeDetail(
       challengeId: challengeId
     )
     challengeDetailViewController.hidesBottomBarWhenPushed = true
     
-    if let sourceView = source as? UIViewController {
+    if let sourceView = self.view as? UIViewController {
       sourceView.navigationController?.pushViewController(
         challengeDetailViewController,
         animated: true

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeRouter.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeRouter.swift
@@ -13,7 +13,11 @@ protocol ChallengeRouterProtocol: AnyObject {
   static func createChallenge() -> UIViewController
 
   func navigateToChallengeDetail(challengeId: Int)
-  func presentBottomSheet()
+  func presentBottomSheet(challengeSortDelegate: ChallengeSortDelegate)
+}
+
+protocol ChallengeSortDelegate: AnyObject {
+  func getSortType(sortType: ChallengeSortType)
 }
 
 final class ChallengeRouter: ChallengeRouterProtocol {
@@ -37,10 +41,12 @@ final class ChallengeRouter: ChallengeRouterProtocol {
     return view
   }
 
-  func presentBottomSheet() {
+  func presentBottomSheet(challengeSortDelegate: ChallengeSortDelegate) {
     guard let sourceView = self.view as? UIViewController else { return }
 
-    let bottomSheetViewController = BottomSheetRouter.createBottomSheet(isChallenge: true)
+    let bottomSheetViewController = BottomSheetRouter.createBottomSheet(
+      challengeSortDelegate: challengeSortDelegate
+    )
 
     sourceView.present(
       bottomSheetViewController,

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
@@ -11,7 +11,6 @@ import KKDSKit
 
 protocol ChallengeViewProtocol: AnyObject {
   var interactor: ChallengeInteractorProtocol? { get set }
-  var router: ChallengeRouterProtocol? { get set }
 
   func fetchChallenges(challenges: [Challenge])
 }
@@ -21,7 +20,6 @@ final class ChallengeViewController: BaseViewController<ChallengeView> {
   // MARK: Properties
   
   var interactor: ChallengeInteractorProtocol?
-  var router: ChallengeRouterProtocol?
 
   var challenges: [Challenge] = []
   
@@ -37,6 +35,8 @@ final class ChallengeViewController: BaseViewController<ChallengeView> {
     self.tabBarController?.tabBar.isHidden = false
     self.setNavigationItem()
   }
+
+  // MARK: - Configure
 
   override func setupConfigure() {
     self.containerView.challengeCollectionView.do {
@@ -64,12 +64,14 @@ final class ChallengeViewController: BaseViewController<ChallengeView> {
     self.navigationItem.rightBarButtonItem = searchBarButtonItem
   }
 
-  @objc func tapSortChallengeButton(_ sender: UIButton) {
-    let bottomSheetViewController = BottomSheetRouter.createBottomSheet(isChallenge: true)
+  // MARK: - Button Actions
 
-    self.present(bottomSheetViewController, animated: false, completion: nil)
+  @objc func tapSortChallengeButton(_ sender: UIButton) {
+    self.interactor?.presentBottomSheet()
   }
 }
+
+// MARK: - Challenge View Protocol
 
 extension ChallengeViewController: ChallengeViewProtocol {
   func fetchChallenges(challenges: [Challenge]) {
@@ -77,6 +79,8 @@ extension ChallengeViewController: ChallengeViewProtocol {
     self.containerView.challengeCollectionView.reloadData()
   }
 }
+
+// MARK: - UICollectionView Data Source
 
 extension ChallengeViewController: UICollectionViewDataSource {
   func collectionView(
@@ -112,8 +116,7 @@ extension ChallengeViewController: UICollectionViewDelegate {
     _ collectionView: UICollectionView,
     didSelectItemAt indexPath: IndexPath
   ) {
-    self.router?.navigateToChallengeDetail(
-      source: self,
+    self.interactor?.navigateToChallengeDetail(
       challengeId: challenges[indexPath.item].id
     )
   }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
@@ -98,7 +98,10 @@ extension ChallengeViewController: UICollectionViewDataSource {
     let challenge = self.challenges[indexPath.row]
 
     cell.backgroundColor = .white
-    cell.bind(data: challenge)
+    
+    DispatchQueue.main.async {
+      cell.bind(data: challenge)
+    }
 
     return cell
   }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
@@ -65,15 +65,8 @@ final class ChallengeViewController: BaseViewController<ChallengeView> {
   }
 
   @objc func tapSortChallengeButton(_ sender: UIButton) {
-    let bottomSheetViewController = BottomSheetViewController()
-    bottomSheetViewController.setBottomSheetContents(
-      contents: [
-        BottomSheetOption.postEdit.rawValue,
-        BottomSheetOption.postDelete.rawValue
-      ],
-      bottomSheetType: .small
-    )
-    bottomSheetViewController.modalPresentationStyle = .overFullScreen
+    let bottomSheetViewController = BottomSheetRouter.createBottomSheet(isChallenge: true)
+
     self.present(bottomSheetViewController, animated: false, completion: nil)
   }
 }
@@ -96,12 +89,17 @@ extension ChallengeViewController: UICollectionViewDataSource {
     _ collectionView: UICollectionView,
     cellForItemAt indexPath: IndexPath
   ) -> UICollectionViewCell {
+
     let cell = collectionView.dequeueReusableCell(
       withReuseIdentifier: ChallengeCell.reusableIdentifier,
-      for: indexPath) as! ChallengeCell
+      for: indexPath)
+    as! ChallengeCell
+
     let challenge = self.challenges[indexPath.row]
+
     cell.backgroundColor = .white
     cell.bind(data: challenge)
+
     return cell
   }
 }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
@@ -12,7 +12,7 @@ import KKDSKit
 protocol ChallengeViewProtocol: AnyObject {
   var interactor: ChallengeInteractorProtocol? { get set }
 
-  func fetchChallenges(challenges: [Challenge], sortType: String)
+  func fetchChallenges(challenges: [Challenge], sortType: ChallengeSortType)
 }
 
 final class ChallengeViewController: BaseViewController<ChallengeView> {
@@ -28,7 +28,7 @@ final class ChallengeViewController: BaseViewController<ChallengeView> {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setNavigationItem()
-    self.interactor?.fetchChallenge(sortType: ChallengeSortType.new.rawValue)
+    self.interactor?.fetchChallenge(sortType: ChallengeSortType.new)
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -74,7 +74,7 @@ final class ChallengeViewController: BaseViewController<ChallengeView> {
 // MARK: - Challenge View Protocol
 
 extension ChallengeViewController: ChallengeViewProtocol {
-  func fetchChallenges(challenges: [Challenge], sortType: String) {
+  func fetchChallenges(challenges: [Challenge], sortType: ChallengeSortType) {
     self.challenges = challenges
 
     DispatchQueue.main.async {

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeViewController.swift
@@ -12,7 +12,7 @@ import KKDSKit
 protocol ChallengeViewProtocol: AnyObject {
   var interactor: ChallengeInteractorProtocol? { get set }
 
-  func fetchChallenges(challenges: [Challenge])
+  func fetchChallenges(challenges: [Challenge], sortType: String)
 }
 
 final class ChallengeViewController: BaseViewController<ChallengeView> {
@@ -28,7 +28,7 @@ final class ChallengeViewController: BaseViewController<ChallengeView> {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setNavigationItem()
-    self.interactor?.fetchChallenge()
+    self.interactor?.fetchChallenge(sortType: ChallengeSortType.new.rawValue)
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -74,9 +74,13 @@ final class ChallengeViewController: BaseViewController<ChallengeView> {
 // MARK: - Challenge View Protocol
 
 extension ChallengeViewController: ChallengeViewProtocol {
-  func fetchChallenges(challenges: [Challenge]) {
+  func fetchChallenges(challenges: [Challenge], sortType: String) {
     self.challenges = challenges
-    self.containerView.challengeCollectionView.reloadData()
+
+    DispatchQueue.main.async {
+      self.containerView.setSortButton(sortType: sortType)
+      self.containerView.challengeCollectionView.reloadData()
+    }
   }
 }
 
@@ -102,10 +106,8 @@ extension ChallengeViewController: UICollectionViewDataSource {
     let challenge = self.challenges[indexPath.row]
 
     cell.backgroundColor = .white
-    
-    DispatchQueue.main.async {
-      cell.bind(data: challenge)
-    }
+
+    cell.bind(data: challenge)
 
     return cell
   }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeWorker.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeWorker.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol ChallengeWorkerProtocol: AnyObject {
-  func fetchChallenge(completionHandler: @escaping ([Challenge]) -> Void)
+  func fetchChallenge(sortType: String, completionHandler: @escaping ([Challenge]) -> Void)
 }
 
 final class ChallengeWorker: ChallengeWorkerProtocol {
@@ -19,8 +19,13 @@ final class ChallengeWorker: ChallengeWorkerProtocol {
     self.repository = repository
   }
   
-  func fetchChallenge(completionHandler: @escaping ([Challenge]) -> Void) {
-    repository.fetchChellenge(completionHandler: { result in
+  func fetchChallenge(
+    sortType: String,
+    completionHandler: @escaping ([Challenge]) -> Void
+  ) {
+    repository.fetchChellenge(
+      sortType: sortType,
+      completionHandler: { result in
       completionHandler(result)
     })
   }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeWorker.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeWorker.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol ChallengeWorkerProtocol: AnyObject {
-  func fetchChallenge(sortType: String, completionHandler: @escaping ([Challenge]) -> Void)
+  func fetchChallenge(sortType: ChallengeSortType, completionHandler: @escaping ([Challenge]) -> Void)
 }
 
 final class ChallengeWorker: ChallengeWorkerProtocol {
@@ -20,11 +20,11 @@ final class ChallengeWorker: ChallengeWorkerProtocol {
   }
   
   func fetchChallenge(
-    sortType: String,
+    sortType: ChallengeSortType,
     completionHandler: @escaping ([Challenge]) -> Void
   ) {
     repository.fetchChellenge(
-      sortType: sortType,
+      sortType: sortType.rawValue,
       completionHandler: { result in
       completionHandler(result)
     })

--- a/KnockKnock-iOS/Scenes/Challenge/Main/Views/ChallengeView.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/Views/ChallengeView.swift
@@ -77,18 +77,13 @@ final class ChallengeView: UIView {
 
   // MARK: - Bind
 
-  func setSortButton(sortType: String) {
-    let type = ChallengeSortType(rawValue: sortType)
-
-    switch type {
+  func setSortButton(sortType: ChallengeSortType) {
+    switch sortType {
     case .new:
       self.sortChallengeButton.setTitle("최신순", for: .normal)
-
+      
     case .popular:
       self.sortChallengeButton.setTitle("인기순", for: .normal)
-
-    case .none:
-      self.sortChallengeButton.setTitle("최신순", for: .normal)
     }
   }
 
@@ -104,17 +99,14 @@ final class ChallengeView: UIView {
       self.headerView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: Metric.headerViewLeadingMargin),
       self.headerView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: Metric.headerViewTrailingMargin),
 
-      self.totalChallengeLabel.topAnchor.constraint(equalTo: self.headerView.topAnchor),
-      self.totalChallengeLabel.bottomAnchor.constraint(equalTo: self.headerView.bottomAnchor),
+      self.totalChallengeLabel.centerYAnchor.constraint(equalTo: self.headerView.centerYAnchor),
       self.totalChallengeLabel.leadingAnchor.constraint(equalTo: self.headerView.leadingAnchor),
 
-      self.numOfNewChallengeLabel.topAnchor.constraint(equalTo: self.headerView.topAnchor),
-      self.numOfNewChallengeLabel.bottomAnchor.constraint(equalTo: self.headerView.bottomAnchor),
+      self.numOfNewChallengeLabel.centerYAnchor.constraint(equalTo: self.headerView.centerYAnchor),
       self.numOfNewChallengeLabel.leadingAnchor.constraint(equalTo: self.totalChallengeLabel.trailingAnchor),
 
-      self.sortChallengeButton.topAnchor.constraint(equalTo: self.headerView.topAnchor),
       self.sortChallengeButton.trailingAnchor.constraint(equalTo: self.headerView.trailingAnchor),
-      self.sortChallengeButton.bottomAnchor.constraint(equalTo: self.headerView.bottomAnchor),
+      self.sortChallengeButton.centerYAnchor.constraint(equalTo: self.headerView.centerYAnchor),
 
       self.challengeCollectionView.topAnchor.constraint(equalTo: self.headerView.bottomAnchor, constant: Metric.challengeCollectionViewTopMargin),
       self.challengeCollectionView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor),

--- a/KnockKnock-iOS/Scenes/Challenge/Main/Views/ChallengeView.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/Views/ChallengeView.swift
@@ -74,6 +74,25 @@ final class ChallengeView: UIView {
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
   }
+
+  // MARK: - Bind
+
+  func setSortButton(sortType: String) {
+    let type = ChallengeSortType(rawValue: sortType)
+
+    switch type {
+    case .new:
+      self.sortChallengeButton.setTitle("최신순", for: .normal)
+
+    case .popular:
+      self.sortChallengeButton.setTitle("인기순", for: .normal)
+
+    case .none:
+      self.sortChallengeButton.setTitle("최신순", for: .normal)
+    }
+  }
+
+  // MARK: - Constraints
   
   private func setupConstraints() {
     [self.numOfNewChallengeLabel, self.totalChallengeLabel, self.sortChallengeButton].addSubViews(self.headerView)

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
@@ -184,7 +184,7 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
         for item in items {
           switch item {
           case let .photo(photo):
-            let resizeImage = await photo.image.resize(newWidth: self.containerView.frame.width)
+            let resizeImage = await photo.image.resizeSquareImage(newWidth: self.containerView.frame.width)
             images.append(resizeImage)
 
             self.selectedImages = images

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/shopSearch/ShopSearchRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/shopSearch/ShopSearchRouter.swift
@@ -69,8 +69,7 @@ final class ShopSearchRouter: ShopSearchRouterProtocol {
   ) {
     guard let bottomSheetViewController = BottomSheetRouter.createBottomSheet(
       districtSelectDelegate: self.districtSelectDelegate,
-      districtsType: districtsType,
-      isMyPost: nil
+      districtsType: districtsType
     ) as? BottomSheetViewController else { return }
 
     bottomSheetViewController.setBottomSheetContents(contents: content, bottomSheetType: .large)


### PR DESCRIPTION
## What is this PR?
- 인기순/최신순으로 챌린지 데이터를 정렬할 수 있습니다.

## Changes
- 챌린지 목록 조회 api에 `sort` 파라미터를 추가하여 타입에 따라 정렬 된 챌린지 리스트를 받아옵니다.
- 정렬 버튼을 누르면 바텀 모달을 통해 정렬 메뉴를 보여주고, 선택한 정렬 타입을 `delegate`를 이용하여 챌린지 화면에 전달합니다.

https://user-images.githubusercontent.com/40792935/216254534-5449b643-320d-455b-b41d-7d11a36c1614.MP4


## Test Checklist
- none.
