### PR TITLE
[FEAT] 피드 상세 좋아요 리스트 업데이트

### DIFF
--- a/KnockKnock-iOS/Scenes/Cells/LikeCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/LikeCell.swift
@@ -27,7 +27,8 @@ final class LikeCell: BaseCollectionViewCell {
   private let profileImageView = UIImageView().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
     $0.image = KKDS.Image.ic_person_24
-    
+    $0.layer.cornerRadius = (Metric.profileImageViewWidth / 2)
+    $0.clipsToBounds = true
     $0.contentMode = .scaleToFill
   }
   
@@ -54,6 +55,13 @@ final class LikeCell: BaseCollectionViewCell {
       self.profileImageView.isHidden = false
       self.likeImageView.isHidden = false
     }
+  }
+
+  func setImage(imageUrl: String?) {
+    self.profileImageView.setImageFromStringUrl(
+      stringUrl: imageUrl,
+      defaultImage: KKDS.Image.ic_like_circle_16
+    )
   }
   
   // MARK: - Constraints

--- a/KnockKnock-iOS/Scenes/Cells/LikeDetailCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/LikeDetailCell.swift
@@ -31,6 +31,8 @@ final class LikeDetailCell: BaseCollectionViewCell {
 
   private let profileImageView = UIImageView().then {
     $0.image = KKDS.Image.ic_person_24
+    $0.layer.cornerRadius = (Metric.profileImageViewWidth / 2)
+    $0.clipsToBounds = true
   }
 
   private let likeImageView = UIImageView().then {
@@ -52,12 +54,11 @@ final class LikeDetailCell: BaseCollectionViewCell {
   // MARK: - Bind
 
   func bind(like: Like.Info) {
-    if let image = like.userImage {
-      self.profileImageView.image = UIImage(named: image)
-    } else {
-      self.profileImageView.image = KKDS.Image.ic_person_24
-    }
-      self.userNameLabel.text = like.userName
+    self.profileImageView.setImageFromStringUrl(
+      stringUrl: like.userImage,
+      defaultImage: KKDS.Image.ic_person_24
+    )
+    self.userNameLabel.text = like.userName
   }
 
   // MARK: - Constraints

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -76,7 +76,10 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
           // error handle
           return
         }
+        self.feedDetail = self.worker?.toggleLike(feedDetail: self.feedDetail)
+
         self.presenter?.presentLikeStatus(isToggle: isSuccess)
+        self.fetchLikeList(feedId: feedId)
       }
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -28,40 +28,13 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
   var interactor: FeedDetailInteractorProtocol?
 
   var feedId: Int = 6
-  var feedDetail: FeedDetail? {
-    didSet {
-      if let feed = feedDetail?.feed {
-        self.containerView.navigationView.bind(feed: feed)
-        self.feedId = feed.id
-        self.containerView.bind(isLike: feed.isLike)
-      }
-
-      self.containerView.postCollectionView.reloadData()
-      self.containerView.layoutIfNeeded()
-    }
-  }
-
   var commentId: Int?
   var allCommentsCount: Int = 0
-  var visibleComments: [Comment] = [] {
-    didSet {
-      UIView.performWithoutAnimation {
-        self.containerView.postCollectionView.reloadSections(
-          IndexSet(integer: FeedDetailSection.comment.rawValue)
-        )
-      }
-    }
-  }
 
-  var like: [Like.Info] = [] {
-    didSet {
-      UIView.performWithoutAnimation {
-        self.containerView.postCollectionView.reloadSections(
-          IndexSet(integer: FeedDetailSection.like.rawValue)
-        )
-      }
-    }
-  }
+  var feedDetail: FeedDetail?
+  var visibleComments: [Comment] = []
+
+  var like: [Like.Info] = []
 
   // MARK: - Life Cycles
   
@@ -277,6 +250,17 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
 extension FeedDetailViewController: FeedDetailViewProtocol {
   func getFeedDetail(feedDetail: FeedDetail) {
     self.feedDetail = feedDetail
+
+    DispatchQueue.main.async {
+      if let feed = self.feedDetail?.feed {
+        self.containerView.navigationView.bind(feed: feed)
+        self.feedId = feed.id
+        self.containerView.bind(isLike: feed.isLike)
+      }
+
+      self.containerView.postCollectionView.reloadData()
+      self.containerView.layoutIfNeeded()
+    }
   }
   
   func getAllCommentsCount(allCommentsCount: Int) {
@@ -285,6 +269,14 @@ extension FeedDetailViewController: FeedDetailViewProtocol {
   
   func fetchVisibleComments(visibleComments: [Comment]) {
     self.visibleComments = visibleComments
+
+    DispatchQueue.main.async {
+      UIView.performWithoutAnimation {
+        self.containerView.postCollectionView.reloadSections(
+          IndexSet(integer: FeedDetailSection.comment.rawValue)
+        )
+      }
+    }
   }
   
   func deleteComment() {
@@ -293,6 +285,14 @@ extension FeedDetailViewController: FeedDetailViewProtocol {
   
   func fetchLikeList(like: [Like.Info]) {
     self.like = like
+
+    DispatchQueue.main.async {
+      UIView.performWithoutAnimation {
+        self.containerView.postCollectionView.reloadSections(
+          IndexSet(integer: FeedDetailSection.like.rawValue)
+        )
+      }
+    }
   }
 
   func fetchLikeStatus(isToggle: Bool) {
@@ -359,9 +359,12 @@ extension FeedDetailViewController: UICollectionViewDataSource {
       )
       if indexPath.item == self.like.count {
         cell.bind(isLast: true)
+
       } else {
         cell.bind(isLast: false)
+        cell.setImage(imageUrl: self.like[indexPath.item].userImage)
       }
+
       return cell
       
     case .comment:

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -18,7 +18,7 @@ protocol FeedDetailWorkerProtocol {
     completionHandler: @escaping (Bool) -> Void
   )
 
-  func toggleLike(feedDetail: FeedDetail) -> FeedDetail
+  func toggleLike(feedDetail: FeedDetail?) -> FeedDetail?
   func fetchLikeList(feedId: Int, completionHandler: @escaping ([Like.Info]) -> Void)
 
   func getAllComments(feedId: Int, completionHandler: @escaping ([Comment]) -> Void)
@@ -173,10 +173,10 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
     }
   }
 
-  func toggleLike(feedDetail: FeedDetail) -> FeedDetail {
+  func toggleLike(feedDetail: FeedDetail?) -> FeedDetail? {
     var feedDetail = feedDetail
 
-    feedDetail.feed?.isLike.toggle()
+    feedDetail?.feed?.isLike.toggle()
 
     return feedDetail
   }


### PR DESCRIPTION
## What is this PR?
- 피드 상세 내부에서 좋아요/취소 이벤트 발생 시 좋아요 리스트가 업데이트 됩니다.

## Changes
- 좋아요 api 성공시 좋아요 리스트를 fetch 합니다.
- 좋아요 리스트/ 좋아요 리스트 상세보기 이미지 바인딩 처리를 하였습니다.
- 로딩 인디케이터가 사라질 때까지 피드 상세 데이터가 로드되지 않는 이슈를 처리하였습니다.

## Test Checklist
- none.