### PR TITLE
[FEAT] 댓글 삭제/등록 시 댓글 개수 업데이트

### DIFF
--- a/KnockKnock-iOS/Entity/Feed/FeedList.swift
+++ b/KnockKnock-iOS/Entity/Feed/FeedList.swift
@@ -21,7 +21,7 @@ struct FeedList: Decodable {
     let imageScale: String = "1:1"
     var blogLikeCount: String
     var isLike: Bool
-    let blogCommentCount: String
+    var blogCommentCount: String
     let blogImages: [Image]
     let isWriter: Bool
 

--- a/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
@@ -22,4 +22,11 @@ extension Notification.Name {
   static let feedListRefreshAfterDelete = Notification.Name("feedListRefreshedAfterDelete")
 
   static let postLikeToggled = Notification.Name("postLikeToggled")
+
+  // Comment
+  static let feedListCommentRefreshAfterDelete = Notification.Name("feedListCommentRefreshAfterDelete")
+  static let feedListCommentRefreshAfterAdd = Notification.Name("feedListCommentRefreshAfterAdd")
+
+  static let feedDetailCommentRefreshAfterDelete = Notification.Name("feedDetailCommentRefreshAfterDelete")
+  static let feedDetailCommentRefreshAfterAdd = Notification.Name("feedDetailCommentRefreshAfteAdd")
 }

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
@@ -66,22 +66,29 @@ final class CommentInteractor: CommentInteractorProtocol {
   func requestDeleteComment(commentId: Int) {
     self.worker?.requestDeleteComment(
       commentId: commentId,
-      completionHandler: {
+      completionHandler: { isSuccess in
 
-        if let index = self.comments.firstIndex(where: { $0.data.id == commentId }) {
-          self.comments[index].data.isDeleted = true
-        }
+        if isSuccess {
 
-        for commentIndex in 0..<self.comments.count {
-          if let replyIndex = self.comments[commentIndex].data.reply?.firstIndex(where: {
-            $0.id == commentId
-          }) {
-            self.comments[commentIndex].data.reply?[replyIndex].isDeleted = true
+          if let index = self.comments.firstIndex(where: { $0.data.id == commentId }) {
+            self.comments[index].data.isDeleted = true
           }
-        }
 
-        self.visibleComments = self.worker?.fetchVisibleComments(comments: self.comments) ?? []
-        self.presenter?.presentVisibleComments(comments: self.visibleComments)
+          for commentIndex in 0..<self.comments.count {
+            if let replyIndex = self.comments[commentIndex].data.reply?.firstIndex(where: {
+              $0.id == commentId
+            }) {
+              self.comments[commentIndex].data.reply?[replyIndex].isDeleted = true
+            }
+          }
+
+          self.visibleComments = self.worker?.fetchVisibleComments(comments: self.comments) ?? []
+          self.presenter?.presentVisibleComments(comments: self.visibleComments)
+
+        } else {
+          
+          // error handle
+        }
       }
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
@@ -54,8 +54,8 @@ final class CommentInteractor: CommentInteractorProtocol {
   func requestAddComment(comment: AddCommentDTO) {
     self.worker?.requestAddComment(
       comment: comment,
-      completionHandler: { success in
-        if success {
+      completionHandler: { isSuccess in
+        if isSuccess {
           self.fetchAllComments(feedId: comment.postId)
         }
       }

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
@@ -14,7 +14,7 @@ protocol CommentInteractorProtocol {
   func fetchAllComments(feedId: Int)
   func requestAddComment(comment: AddCommentDTO)
   func toggleVisibleStatus(commentId: Int)
-  func requestDeleteComment(commentId: Int)
+  func requestDeleteComment(feedId: Int, commentId: Int)
 }
 
 final class CommentInteractor: CommentInteractorProtocol {
@@ -63,8 +63,9 @@ final class CommentInteractor: CommentInteractorProtocol {
   }
 
   /// 댓글 삭제
-  func requestDeleteComment(commentId: Int) {
+  func requestDeleteComment(feedId: Int, commentId: Int) {
     self.worker?.requestDeleteComment(
+      feedId: feedId,
       commentId: commentId,
       completionHandler: { isSuccess in
 

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
@@ -102,23 +102,19 @@ final class CommentInteractor: CommentInteractorProtocol {
     self.worker?.requestDeleteComment(
       feedId: feedId,
       commentId: commentId,
+      comments: self.comments,
       completionHandler: { [weak self] isSuccess in
 
         guard let self = self else { return }
 
         if isSuccess {
 
-          if let index = self.comments.firstIndex(where: { $0.data.id == commentId }) {
-            self.comments[index].data.isDeleted = true
-          }
-
-          for commentIndex in 0..<self.comments.count {
-            if let replyIndex = self.comments[commentIndex].data.reply?.firstIndex(where: {
-              $0.id == commentId
-            }) {
-              self.comments[commentIndex].data.reply?[replyIndex].isDeleted = true
-            }
-          }
+          guard let convertComments = self.worker?.convertDeletedComment(
+            comments: self.comments,
+            commentId: commentId
+          ) else { return }
+          
+          self.comments = convertComments
 
           self.visibleComments = self.worker?.fetchVisibleComments(comments: self.comments) ?? []
           self.presenter?.presentVisibleComments(comments: self.visibleComments)

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
@@ -14,7 +14,14 @@ protocol CommentInteractorProtocol {
   func fetchAllComments(feedId: Int)
   func requestAddComment(comment: AddCommentDTO)
   func toggleVisibleStatus(commentId: Int)
-  func requestDeleteComment(feedId: Int, commentId: Int)
+  func requestDeleteComment(
+    feedId: Int,
+    commentId: Int
+  )
+  func showAlertView(
+    message: String,
+    confirmAction: (() -> Void)?
+  )
 }
 
 final class CommentInteractor: CommentInteractorProtocol {
@@ -55,15 +62,25 @@ final class CommentInteractor: CommentInteractorProtocol {
     self.worker?.requestAddComment(
       comment: comment,
       completionHandler: { isSuccess in
+
         if isSuccess {
           self.fetchAllComments(feedId: comment.postId)
+
+        } else {
+          self.showAlertView(
+            message: "댓글 등록에 실패하였습니다.",
+            confirmAction: nil
+          )
         }
       }
     )
   }
 
   /// 댓글 삭제
-  func requestDeleteComment(feedId: Int, commentId: Int) {
+  func requestDeleteComment(
+    feedId: Int,
+    commentId: Int
+  ) {
     self.worker?.requestDeleteComment(
       feedId: feedId,
       commentId: commentId,
@@ -87,10 +104,23 @@ final class CommentInteractor: CommentInteractorProtocol {
           self.presenter?.presentVisibleComments(comments: self.visibleComments)
 
         } else {
-          
-          // error handle
+
+          self.showAlertView(
+            message: "댓글 삭제에 실패하였습니다.",
+            confirmAction: nil
+          )
         }
       }
+    )
+  }
+
+  func showAlertView(
+    message: String,
+    confirmAction: (() -> Void)?
+  ) {
+    self.router?.showAlertView(
+      message: message,
+      confirmAction: confirmAction
     )
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentRouter.swift
@@ -11,6 +11,10 @@ protocol CommentRouterProtocol {
   static func createCommentView(feedId: Int) -> UIViewController
   func dismissCommentView(view: CommentViewProtocol)
   func presentBottomSheetView(source: CommentViewProtocol)
+  func showAlertView(
+    message: String,
+    confirmAction: (() -> Void)?
+  )
 }
 
 final class CommentRouter: CommentRouterProtocol {
@@ -54,6 +58,20 @@ final class CommentRouter: CommentRouterProtocol {
         bottomSheetViewController,
         animated: false,
         completion: nil
+      )
+    }
+  }
+
+  /// AlertView
+  func showAlertView(
+    message: String,
+    confirmAction: (() -> Void)?
+  ) {
+    if let sourceView = self.view as? UIViewController {
+      sourceView.showAlert(
+        content: message,
+        isCancelActive: false,
+        confirmActionCompletion: confirmAction
       )
     }
   }

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentRouter.swift
@@ -8,9 +8,11 @@
 import UIKit
 
 protocol CommentRouterProtocol {
+  var view: CommentViewProtocol? { get set }
+
   static func createCommentView(feedId: Int) -> UIViewController
-  func dismissCommentView(view: CommentViewProtocol)
-  func presentBottomSheetView(source: CommentViewProtocol)
+
+  func dismissCommentView()
   func showAlertView(
     message: String,
     confirmAction: (() -> Void)?
@@ -18,51 +20,37 @@ protocol CommentRouterProtocol {
 }
 
 final class CommentRouter: CommentRouterProtocol {
-  
+  weak var view: CommentViewProtocol?
+
   static func createCommentView(feedId: Int) -> UIViewController {
     let view = CommentViewController()
     let interactor = CommentInteractor()
     let presenter = CommentPresenter()
     let worker = CommentWorker(repository: CommentRepository())
     let router = CommentRouter()
-    
-    view.router = router
+
     view.interactor = interactor
     view.feedId = feedId
     interactor.presenter = presenter
     interactor.worker = worker
+    interactor.router = router
     presenter.view = view
-    
+    router.view = view
+
     return view
   }
-  
-  func dismissCommentView(view: CommentViewProtocol) {
-    if let view = view as? UIViewController {
+
+  func dismissCommentView() {
+    if let view = self.view as? UIViewController {
       view.dismiss(animated: true)
-    }
-  }
-  
-  func presentBottomSheetView(source: CommentViewProtocol) {
-    let bottomSheetViewController = BottomSheetViewController().then {
-      $0.setBottomSheetContents(
-        contents: [
-          BottomSheetOption.postDelete.rawValue,
-          BottomSheetOption.postEdit.rawValue
-        ],
-        bottomSheetType: .small
-      )
-      $0.modalPresentationStyle = .overFullScreen
-    }
-    if let sourceView = source as? UIViewController {
-      sourceView.present(
-        bottomSheetViewController,
-        animated: false,
-        completion: nil
-      )
     }
   }
 
   /// AlertView
+  ///
+  /// - Parameters:
+  ///  - message: 알림창 메세지
+  ///  - confirmAction: 확인 눌렀을 때 수행 될 액션
   func showAlertView(
     message: String,
     confirmAction: (() -> Void)?

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentViewController.swift
@@ -154,7 +154,10 @@ final class CommentViewController: BaseViewController<CommentView> {
     self.showAlert(
       content: "댓글을 삭제하시겠습니까?",
       confirmActionCompletion: {
-        self.interactor?.requestDeleteComment(commentId: commentId)
+        self.interactor?.requestDeleteComment(
+          feedId: self.feedId,
+          commentId: commentId
+        )
       }
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentViewController.swift
@@ -10,8 +10,7 @@ import Foundation
 import Then
 import KKDSKit
 
-protocol CommentViewProtocol {
-  var router: CommentRouterProtocol? { get set }
+protocol CommentViewProtocol: AnyObject {
   var interactor: CommentInteractorProtocol? { get set }
   
   func fetchVisibleComments(comments: [Comment])
@@ -20,8 +19,7 @@ protocol CommentViewProtocol {
 final class CommentViewController: BaseViewController<CommentView> {
   
   // MARK: - Properties
-  
-  var router: CommentRouterProtocol?
+
   var interactor: CommentInteractorProtocol?
   
   var visibleComments: [Comment] = [] {
@@ -138,7 +136,7 @@ final class CommentViewController: BaseViewController<CommentView> {
   // MARK: - Button action
   
   @objc private func exitButtonDidTap(_ sender: UIButton) {
-    self.router?.dismissCommentView(view: self)
+    self.interactor?.dismissCommentView()
   }
   
   @objc private func replyWriteButtonDidTap(_ sender: UIButton) {

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentWorker.swift
@@ -11,7 +11,7 @@ protocol CommentWorkerProtocol {
   func getAllComments(feedId: Int, completionHandler: @escaping ([Comment]) -> Void)
   func requestAddComment(comment: AddCommentDTO, completionHandler: @escaping (Bool) -> Void)
   func fetchVisibleComments(comments: [Comment]?) -> [Comment]
-  func requestDeleteComment(commentId: Int, completionHandler: @escaping (Bool) -> Void)
+  func requestDeleteComment(feedId: Int, commentId: Int, completionHandler: @escaping (Bool) -> Void)
 }
 
 final class CommentWorker: CommentWorkerProtocol {
@@ -101,6 +101,7 @@ final class CommentWorker: CommentWorkerProtocol {
   }
 
   func requestDeleteComment(
+    feedId: Int,
     commentId: Int,
     completionHandler: @escaping OnCompletionHandler
   ) {
@@ -108,7 +109,7 @@ final class CommentWorker: CommentWorkerProtocol {
       commentId: commentId,
       completionHandler: { isSuccess in
         if isSuccess {
-          self.postDeleteNotificationEvent(feedId: commentId)
+          self.postDeleteNotificationEvent(feedId: feedId)
         }
         completionHandler(isSuccess)
       }

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentWorker.swift
@@ -123,20 +123,11 @@ extension CommentWorker {
       name: .feedListCommentRefreshAfterAdd,
       object: feedId
     )
-    NotificationCenter.default.post(
-      name: .feedDetailCommentRefreshAfterAdd,
-      object: feedId
-    )
-
   }
 
   private func postDeleteNotificationEvent(feedId: Int) {
     NotificationCenter.default.post(
       name: .feedListCommentRefreshAfterDelete,
-      object: feedId
-    )
-    NotificationCenter.default.post(
-      name: .feedDetailCommentRefreshAfterDelete,
       object: feedId
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -63,8 +63,11 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
     self.worker?.getFeedDetail(
       feedId: feedId,
       completionHandler: { [weak self] feedDetail in
-        self?.feedDetail = feedDetail
-        self?.presenter?.presentFeedDetail(feedDetail: feedDetail)
+        
+        guard let self = self else { return }
+
+        self.feedDetail = feedDetail
+        self.presenter?.presentFeedDetail(feedDetail: feedDetail)
       }
     )
   }
@@ -84,7 +87,9 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
       isLike: isLike,
       feedId: feedId,
       completionHandler: { [weak self] isSuccess in
+
         guard let self = self else { return }
+
         guard isSuccess else {
           // error handle
           return
@@ -101,8 +106,11 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
     self.worker?.fetchLikeList(
       feedId: feedId,
       completionHandler: { [weak self] likeList in
-        self?.likeList = likeList
-        self?.presenter?.presentLikeList(like: likeList)
+
+        guard let self = self else { return }
+
+        self.likeList = likeList
+        self.presenter?.presentLikeList(like: likeList)
       }
     )
   }
@@ -112,10 +120,13 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
     self.worker?.getAllComments(
       feedId: feedId,
       completionHandler: { [weak self] comments in
-        self?.comments = comments
-        self?.fetchAllCommentsCount(comments: comments)
-        self?.visibleComments = self?.worker?.fetchVisibleComments(comments: self?.comments) ?? []
-        self?.presenter?.presentVisibleComments(comments: self?.visibleComments ?? [])
+
+        guard let self = self else { return }
+
+        self.comments = comments
+        self.fetchAllCommentsCount(comments: comments)
+        self.visibleComments = self.worker?.fetchVisibleComments(comments: self.comments) ?? []
+        self.presenter?.presentVisibleComments(comments: self.visibleComments)
       }
     )
   }
@@ -154,7 +165,9 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
   ) {
     self.worker?.requestAddComment(
       comment: comment,
-      completionHandler: { isSuccess in
+      completionHandler: { [weak self] isSuccess in
+
+        guard let self = self else { return }
 
         if isSuccess {
           self.fetchAllComments(feedId: comment.postId)
@@ -175,8 +188,10 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
     self.worker?.requestDeleteComment(
       feedId: feedId,
       commentId: commentId,
-      completionHandler: { isSuccess in
-        
+      completionHandler: { [weak self] isSuccess in
+
+        guard let self = self else { return }
+
         if isSuccess {
           if let index = self.comments.firstIndex(where: { $0.data.id == commentId }) {
             self.comments[index].data.isDeleted = true
@@ -210,7 +225,10 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
 
     self.worker?.requestDeleteFeed(
       feedId: feedId,
-      completionHandler: { isSuccess in
+      completionHandler: { [weak self] isSuccess in
+
+        guard let self = self else { return }
+
         if isSuccess {
           self.showAlertView(
             message: "게시글이 삭제되었습니다.",
@@ -234,7 +252,9 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
 
     self.worker?.requestHidePost(
       feedId: feedId,
-      completionHandler: { isSuccess in
+      completionHandler: { [weak self] isSuccess in
+
+        guard let self = self else { return }
 
         if isSuccess {
           self.showAlertView(

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -113,6 +113,7 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
       feedId: feedId,
       completionHandler: { [weak self] comments in
         self?.comments = comments
+        self?.fetchAllCommentsCount(comments: comments)
         self?.visibleComments = self?.worker?.fetchVisibleComments(comments: self?.comments) ?? []
         self?.presenter?.presentVisibleComments(comments: self?.visibleComments ?? [])
       }
@@ -132,10 +133,10 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
   }
 
   /// 답글을 포함한 모든 댓글의 수 (헤더에 표기)
-  func fetchAllCommentsCount(comments: [Comment]) {
-    var count = comments.count
-    
-    comments.forEach {
+  func fetchAllCommentsCount(comments: [Comment]?) {
+    var count = comments?.count ?? 0
+
+    comments?.forEach {
       count += $0.data.reply?.count ?? 0
     }
     self.presenter?.presentAllCommentsCount(allCommentsCount: count)
@@ -156,6 +157,7 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
       completionHandler: { success in
         if success {
           self.fetchAllComments(feedId: comment.postId)
+          self.fetchAllCommentsCount(comments: self.comments)
         }
       }
     )
@@ -180,9 +182,10 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
               self.comments[commentIndex].data.reply?[replyIndex].isDeleted = true
             }
           }
-          
+
           self.visibleComments = self.worker?.fetchVisibleComments(comments: self.comments) ?? []
           self.presenter?.presentVisibleComments(comments: self.visibleComments)
+          self.fetchAllCommentsCount(comments: self.visibleComments)
         } else {
           
           //error

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -124,7 +124,7 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
         guard let self = self else { return }
 
         self.comments = comments
-        self.fetchAllCommentsCount(comments: comments)
+        self.fetchAllCommentsCount()
         self.visibleComments = self.worker?.fetchVisibleComments(comments: self.comments) ?? []
         self.presenter?.presentVisibleComments(comments: self.visibleComments)
       }
@@ -144,11 +144,15 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
   }
 
   /// 답글을 포함한 모든 댓글의 수 (헤더에 표기)
-  func fetchAllCommentsCount(comments: [Comment]?) {
-    var count = comments?.count ?? 0
+  func fetchAllCommentsCount() {
+    var count = self.comments.filter { !$0.data.isDeleted }.count
 
-    comments?.forEach {
-      count += $0.data.reply?.count ?? 0
+    self.comments.forEach { comment in
+      count += comment.data.reply
+        .map {
+          $0.filter { !$0.isDeleted }
+        }?
+        .count ?? 0
     }
     self.presenter?.presentAllCommentsCount(allCommentsCount: count)
   }
@@ -171,7 +175,7 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
 
         if isSuccess {
           self.fetchAllComments(feedId: comment.postId)
-          self.fetchAllCommentsCount(comments: self.comments)
+          self.fetchAllCommentsCount()
 
         } else {
           self.showAlertView(
@@ -207,7 +211,7 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
 
           self.visibleComments = self.worker?.fetchVisibleComments(comments: self.comments) ?? []
           self.presenter?.presentVisibleComments(comments: self.visibleComments)
-          self.fetchAllCommentsCount(comments: self.visibleComments)
+          self.fetchAllCommentsCount()
 
         } else {
           

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -154,10 +154,17 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
   ) {
     self.worker?.requestAddComment(
       comment: comment,
-      completionHandler: { success in
-        if success {
+      completionHandler: { isSuccess in
+
+        if isSuccess {
           self.fetchAllComments(feedId: comment.postId)
           self.fetchAllCommentsCount(comments: self.comments)
+
+        } else {
+          self.showAlertView(
+            message: "댓글 등록에 실패하였습니다.",
+            confirmAction: nil
+          )
         }
       }
     )
@@ -186,9 +193,13 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
           self.visibleComments = self.worker?.fetchVisibleComments(comments: self.comments) ?? []
           self.presenter?.presentVisibleComments(comments: self.visibleComments)
           self.fetchAllCommentsCount(comments: self.visibleComments)
+
         } else {
           
-          //error
+          self.showAlertView(
+            message: "댓글 삭제에 실패하였습니다.",
+            confirmAction: nil
+          )
         }
       }
     )

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -173,7 +173,10 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
     self.showAlert(
       content: "댓글을 삭제하시겠습니까?",
       confirmActionCompletion: {
-        self.interactor?.requestDeleteComment(commentId: commentId)
+        self.interactor?.requestDeleteComment(
+          feedId: self.feedId,
+          commentId: commentId
+        )
       }
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -88,7 +88,9 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
   ) {
     self.feedRepository.requestDeleteFeed(
       feedId: feedId,
-      completionHandler: { isSuccess in
+      completionHandler: { [weak self] isSuccess in
+
+        guard let self = self else { return }
 
         if isSuccess {
           self.postResfreshNotificationEvent(feedId: feedId)
@@ -104,7 +106,9 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
   ) {
     self.feedRepository.requestHidePost(
       feedId: feedId,
-      completionHandler: { isSuccess in
+      completionHandler: { [weak self] isSuccess in
+
+        guard let self = self else { return }
 
         if isSuccess {
           self.postResfreshNotificationEvent(feedId: feedId)
@@ -185,25 +189,29 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
     if !isLike {
       self.likeRepository.requestLike(
         id: feedId,
-        completionHandler: { result in
-          
-          NotificationCenter.default.post(
-            name: .postLikeToggled,
-            object: feedId
-          )
-          completionHandler(result)
+        completionHandler: { [weak self] isSuccess in
+
+          guard let self = self else { return }
+
+          if isSuccess {
+            self.postLikeNotificationEvent(feedId: feedId)
+          }
+
+          completionHandler(isSuccess)
         }
       )
     } else {
       self.likeRepository.requestLikeCancel(
         id: feedId,
-        completionHandler: { result in
+        completionHandler: { [weak self] isSuccess in
 
-          NotificationCenter.default.post(
-            name: .postLikeToggled,
-            object: feedId
-          )
-          completionHandler(result)
+          guard let self = self else { return }
+
+          if isSuccess {
+            self.postLikeNotificationEvent(feedId: feedId)
+          }
+
+          completionHandler(isSuccess)
         }
       )
     }
@@ -235,8 +243,10 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
   ) {
     self.commentRepository.requestAddComment(
       comment: comment,
-      completionHandler: { isSuccess in
-        
+      completionHandler: { [weak self] isSuccess in
+
+        guard let self = self else { return }
+
         if isSuccess {
           self.postCommentAddNotificationEvent(feedId: comment.postId)
         }
@@ -252,7 +262,9 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
   ) {
     self.commentRepository.requestDeleteComment(
       commentId: commentId,
-      completionHandler: { isSuccess in
+      completionHandler: { [weak self] isSuccess in
+
+        guard let self = self else { return }
 
         if isSuccess {
           self.postCommentDeleteNotificationEvent(feedId: feedId)
@@ -274,6 +286,13 @@ extension FeedDetailWorker {
     
     NotificationCenter.default.post(
       name: .feedMainRefreshAfterDelete,
+      object: feedId
+    )
+  }
+
+  private func postLikeNotificationEvent(feedId: Int) {
+    NotificationCenter.default.post(
+      name: .postLikeToggled,
       object: feedId
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
@@ -241,6 +241,7 @@ extension FeedListInteractor {
     self.deletePost(feedList: feedList, feedId: feedId)
   }
 
+  /// 댓글 등록 시 댓글 개수 업데이트
   @objc
   private func addCommentNotificationEvent(_ notification: Notification) {
     guard let feedId = notification.object as? Int else { return }
@@ -254,6 +255,7 @@ extension FeedListInteractor {
     guard let convertFeedList = self.worker?.convertComment(
       feeds: feedListData,
       id: feedId,
+      replyCount: nil,
       isAdded: true
     ) else { return }
 
@@ -271,9 +273,12 @@ extension FeedListInteractor {
     )
   }
 
+  /// 댓글 삭제시 댓글 개수 업데이트
   @objc
   private func deleteCommentNotificationEvent(_ notification: Notification) {
-    guard let feedId = notification.object as? Int else { return }
+    guard let data = notification.object as? [String: Any],
+          let feedId = data["feedId"] as? Int,
+          let replyCount = data["replyCount"] as? Int else { return }
 
     guard let feedListData = self.feedListData else { return }
     guard !feedListData.feeds.isEmpty else { return }
@@ -284,6 +289,7 @@ extension FeedListInteractor {
     guard let convertFeedList = self.worker?.convertComment(
       feeds: feedListData,
       id: feedId,
+      replyCount: replyCount,
       isAdded: false
     ) else { return }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
@@ -278,13 +278,18 @@ extension FeedListViewController: FeedListViewProtocol {
   /// - Parameters:
   ///   - feedList: 업데이트 되어진 피드 리스트
   ///   - sections: 업데이트 된 피드의 Sections
-  func updateFeedList(feedList: FeedList, sections: [IndexPath]) {
+  func updateFeedList(
+    feedList: FeedList,
+    sections: [IndexPath]
+  ) {
     self.feedListPost = feedList.feeds
 
     DispatchQueue.main.async {
       UIView.performWithoutAnimation {
         sections.forEach { indexPath in
-          self.containerView.feedListCollectionView.reloadSections(IndexSet(integer: indexPath.section))
+          self.containerView.feedListCollectionView.reloadSections(
+            IndexSet(integer: indexPath.section)
+          )
         }
       }
     }

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -59,6 +59,7 @@ protocol FeedListWorkerProtocol {
   func convertComment(
     feeds: FeedList,
     id: Int,
+    replyCount: Int?,
     isAdded: Bool
   ) -> FeedList
 }
@@ -268,12 +269,17 @@ final class FeedListWorker: FeedListWorkerProtocol {
   func convertComment(
     feeds: FeedList,
     id: Int,
+    replyCount: Int? = nil,
     isAdded: Bool
   ) -> FeedList {
     var feeds = feeds
 
     self.changedSections(feeds: feeds.feeds, id: id).forEach {
-      self.setCommentCount(feed: &feeds.feeds[$0], isAdded: isAdded)
+      self.setCommentCount(
+        feed: &feeds.feeds[$0],
+        replyCount: replyCount ?? 0,
+        isAdded: isAdded
+      )
     }
 
     return feeds
@@ -328,6 +334,7 @@ extension FeedListWorker {
   ///  - isAdded: 등록 이벤트(true), 삭제 이벤트(false)
   private func setCommentCount(
     feed: inout FeedList.Post,
+    replyCount: Int,
     isAdded: Bool
   ) {
     let title = feed.blogCommentCount.filter { $0.isNumber }
@@ -338,7 +345,7 @@ extension FeedListWorker {
 
     guard let titleToInt = Int(title) else { return }
 
-    let number = isAdded ? (titleToInt + 1) : (titleToInt - 1)
+    let number = isAdded ? (titleToInt + 1) : (titleToInt - (replyCount + 1))
     let newTitle = numberFormatter.string(from: NSNumber(value: number)) ?? ""
 
     feed.blogCommentCount = " \(newTitle)"

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -96,6 +96,7 @@ final class FeedListWorker: FeedListWorkerProtocol {
     )
   }
 
+  /// 게시글 숨기기
   func requestHidePost(
     feedId: Int,
     completionHandler: @escaping (Bool) -> Void
@@ -259,6 +260,11 @@ final class FeedListWorker: FeedListWorkerProtocol {
     return feeds
   }
 
+  /// 댓글 등록/삭제 이벤트 발생 시 댓글 개수 업데이트한 피드 데이터 반환
+  ///
+  /// - Parameters:
+  ///  - feeds: 피드 리스트 데이터
+  ///  - id: 피드 아이디
   func convertComment(
     feeds: FeedList,
     id: Int,
@@ -272,7 +278,6 @@ final class FeedListWorker: FeedListWorkerProtocol {
 
     return feeds
   }
-  
 
   /// 현재 좋아요 상태 체크 (좋아요/비좋아요)
   ///
@@ -316,7 +321,15 @@ extension FeedListWorker {
     feed.blogLikeCount = " \(newTitle)"
   }
 
-  private func setCommentCount(feed: inout FeedList.Post, isAdded: Bool) {
+  /// 댓글 개수
+  ///
+  /// - Parameters:
+  ///  - feed: 피드 리스트 데이터
+  ///  - isAdded: 등록 이벤트(true), 삭제 이벤트(false)
+  private func setCommentCount(
+    feed: inout FeedList.Post,
+    isAdded: Bool
+  ) {
     let title = feed.blogCommentCount.filter { $0.isNumber }
 
     let numberFormatter = NumberFormatter().then {
@@ -331,6 +344,7 @@ extension FeedListWorker {
     feed.blogCommentCount = " \(newTitle)"
   }
 
+  /// Notification
   private func postResfreshNotificationEvent(feedId: Int) {
     NotificationCenter.default.post(
       name: .feedMainRefreshAfterDelete,


### PR DESCRIPTION
## What is this PR?
- 피드 상세와 CommentView에서 댓글 등록 및 삭제 시 피드 상세 헤더의 댓글 개수와 피드 리스트 댓글 버튼 타이틀이 변경됩니다.

## Changes
- 댓글 등록/삭제 이벤트 발생시 피드 리스트에 `NotificationCenter`를 통해 이벤트를 전송합니다.
- 댓글 상세 내 댓글 개수를 카운트 하는 메소드를 정의해 헤더의 댓글 개수를 업데이트하였습니다.
- 순환참조 방지를 위하여 `escaping closure` 내부에 `weak self` 처리를 하였습니다.

https://user-images.githubusercontent.com/40792935/216798384-6c51312e-35c3-4445-9f40-b9b12c5bcc60.mov

## Test Checklist
- 현재 답글이 달린 댓글이 삭제 될 경우 답글이 isDeleted 처리가 되지 않는 api 버그가 있어 댓글 개수에 오류가 있을 수 있습니다.