### PR TITLE
[FEAT] 챌린지 데이터 구조 변경 적용

### DIFF
--- a/KnockKnock-iOS/Entity/Challenge.swift
+++ b/KnockKnock-iOS/Entity/Challenge.swift
@@ -24,7 +24,11 @@ struct Challenge: Decodable {
 }
 
 struct ChallengeDetail: Decodable {
-  let challenge: Header
+  let id: Int
+  let title: String
+  let subTitle: String
+  let contentImage: String
+
   let participants: [Participant]
   let content: Content
 
@@ -33,14 +37,7 @@ struct ChallengeDetail: Decodable {
     let image: String?
   }
 
-  struct Header: Decodable {
-    let id: Int
-    let title: String
-    let subTitle: String
-  }
-
   struct Content: Decodable {
-    let image: String?
     let rule: [String]
     let subContents: [SubContents]
   }

--- a/KnockKnock-iOS/Entity/Challenge.swift
+++ b/KnockKnock-iOS/Entity/Challenge.swift
@@ -11,12 +11,11 @@ struct Challenge: Decodable {
   let id: Int
   let title: String
   let subTitle: String
-  let content: String
-  let regDate: String
-  let newYn: String // 새로운 게시물
-  let postCnt: String // 최신순?
-  let rnk: String // 인기순위?
+  let mainImage: String
+  let isHotBadge: Bool
+  let isNewBadge: Bool
   let participants: [Participant]
+  let participantCount: Int
 
   struct Participant: Decodable {
     let id: Int

--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIStackView+Ext.swift
@@ -18,7 +18,7 @@ extension UIStackView {
     }
   }
 
-  func addParticipantImageViews(images: [String?]) {
+  func addParticipantImageViews(images: [String?]) async {
     var images = images
 
     // 참여자가 없을 경우 디폴트 이미지 1개 내려주기 위해서 nil 삽입
@@ -37,15 +37,25 @@ extension UIStackView {
         $0.clipsToBounds = true
       }
 
-      let profileImage = images[index]
-        .flatMap { URL(string: $0) }
-        .flatMap { try? Data(contentsOf: $0) }
-        .flatMap { UIImage(data: $0) }
-      ?? KKDS.Image.ic_person_24
+      do {
+        if let stringUrl = images[index],
+           let url = URL(string: stringUrl) {
 
-      imageView.image = profileImage.resizeSquareImage(newWidth: 24)
+          let (data, _) = try await URLSession.shared.data(from: url)
+          let image = UIImage(data: data)
+          imageView.image = image?.resizeSquareImage(newWidth: 24)
 
-      addArrangedSubview(imageView)
+        } else {
+          imageView.image = KKDS.Image.ic_person_24
+        }
+
+        addArrangedSubview(imageView)
+
+      } catch {
+
+        imageView.image = KKDS.Image.ic_person_24
+        addArrangedSubview(imageView)
+      }
 
       if index == 2 {
         break

--- a/KnockKnock-iOS/Repository/KakaoShareManager.swift
+++ b/KnockKnock-iOS/Repository/KakaoShareManager.swift
@@ -31,18 +31,17 @@ final class KakaoShareManager: KakaoShareManagerProtocol {
   func shareChallenge(challengeData: ChallengeDetail) -> (Bool, KakaoShareErrorType?) {
 
     let appLink = Link(
-      iosExecutionParams: [ShareQueryItemType.challenge.rawValue: "\(challengeData.challenge.id)"]
+      iosExecutionParams: [ShareQueryItemType.challenge.rawValue: "\(challengeData.id)"]
     )
 
     let button = Button(title: "앱에서 보기", link: appLink)
 
-    if let image = challengeData.content.image,
-       let imageUrl = URL(string: image) {
+    if let imageUrl = URL(string: challengeData.contentImage) {
 
       let content = Content(
-        title: "\(challengeData.challenge.title)",
+        title: "\(challengeData.title)",
         imageUrl: imageUrl,
-        description: challengeData.challenge.subTitle,
+        description: challengeData.subTitle,
         link: appLink
       )
 
@@ -56,7 +55,7 @@ final class KakaoShareManager: KakaoShareManagerProtocol {
     } else {
 
       let textTemplate = generateTextTemplate(
-        text: challengeData.challenge.title,
+        text: challengeData.title,
         appLink: appLink,
         shareQueryItemType: .challenge
       )

--- a/KnockKnock-iOS/Scenes/Cells/ChallengeCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/ChallengeCell.swift
@@ -51,7 +51,6 @@ final class ChallengeCell: BaseCollectionViewCell {
     $0.translatesAutoresizingMaskIntoConstraints = false
     $0.layer.cornerRadius = 5
     $0.clipsToBounds = true
-    $0.image = UIImage(named: "challenge")
   }
   private let titleLabel = UILabel().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
@@ -97,6 +96,7 @@ final class ChallengeCell: BaseCollectionViewCell {
 
   private let newChallengeLabel = UILabel().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
+//    $0.frame = CGRect(x: 0, y: 0, width: Metric.newChallengeLabelWidth, height: Metric.newChallengeLabelHeight)
     $0.backgroundColor = .green50
     $0.textAlignment = .center
     $0.layer.cornerRadius = 3
@@ -108,6 +108,7 @@ final class ChallengeCell: BaseCollectionViewCell {
 
   private let hotChallengeLabel = UILabel().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
+//    $0.frame = CGRect(x: 0, y: 0, width: Metric.newChallengeLabelWidth, height: Metric.newChallengeLabelHeight)
     $0.backgroundColor = UIColor(red: 236/255, green: 124/255, blue: 108/255, alpha: 1)
     $0.textAlignment = .center
     $0.layer.cornerRadius = 3
@@ -116,24 +117,40 @@ final class ChallengeCell: BaseCollectionViewCell {
     $0.font = .systemFont(ofSize: 10, weight: .heavy)
     $0.text = "HOT"
   }
+
+  private let badgeStackView = UIStackView().then {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.axis = .horizontal
+    $0.alignment = .center
+    $0.distribution = .equalSpacing
+    $0.spacing = 5
+  }
   
   // MARK: - Bind
   
   func bind(data: Challenge) {
     self.titleLabel.text = data.title
     self.contentsLabel.text = data.subTitle
+    self.challengeImageView.setImageFromStringUrl(
+      stringUrl: data.mainImage,
+      defaultImage: KKDS.Image.ic_no_data_60
+    )
+
+    self.setBadges(isHot: data.isHotBadge, isNew: data.isNewBadge)
     self.setParticipantsImageStackView(participants: data.participants)
-    self.setParticipantLabel(count: data.participants.count)
+    self.setParticipantLabel(count: data.participantCount)
   }
 
   private func setParticipantsImageStackView(participants: [Challenge.Participant]) {
     var images: [String?] = []
 
-    participants.forEach {
-      images.append($0.image)
+    Task {
+      participants.forEach {
+        images.append($0.image)
+      }
+      self.participantImageStackView.removeAllSubViews()
+      await self.participantImageStackView.addParticipantImageViews(images: images)
     }
-    self.participantImageStackView.removeAllSubViews()
-    self.participantImageStackView.addParticipantImageViews(images: images)
   }
 
   private func setParticipantLabel(count: Int) {
@@ -144,11 +161,24 @@ final class ChallengeCell: BaseCollectionViewCell {
     }
   }
 
+  private func setBadges(
+    isHot: Bool,
+    isNew: Bool
+  ) {
+    if isNew {
+      self.badgeStackView.addArrangedSubview(self.newChallengeLabel)
+    }
+    if isHot {
+      self.badgeStackView.addArrangedSubview(self.hotChallengeLabel)
+    }
+  }
+
   // MARK: - Configure
   
   override func setupConstraints() {
     [self.participantLabel, self.participantImageStackView].addSubViews(self.participantView)
-    [self.challengeImageView, self.participantView, self.seperatorLineView, self.titleLabel, self.contentsLabel, self.newChallengeLabel, self.hotChallengeLabel].addSubViews(self.contentView)
+    [self.challengeImageView, self.participantView, self.seperatorLineView, self.titleLabel, self.contentsLabel,
+     self.badgeStackView].addSubViews(self.contentView)
     
     NSLayoutConstraint.activate([
       self.challengeImageView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
@@ -156,13 +186,13 @@ final class ChallengeCell: BaseCollectionViewCell {
       self.challengeImageView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
       self.challengeImageView.heightAnchor.constraint(equalTo: self.contentView.widthAnchor, multiplier: 0.75),
 
-      self.newChallengeLabel.topAnchor.constraint(equalTo: self.challengeImageView.topAnchor, constant: Metric.newChallengeLabelTopMargin),
-      self.newChallengeLabel.leadingAnchor.constraint(equalTo: self.challengeImageView.leadingAnchor, constant: Metric.newChallengeLabelLeadingMargin),
+      self.badgeStackView.topAnchor.constraint(equalTo: self.challengeImageView.topAnchor, constant: Metric.newChallengeLabelTopMargin),
+      self.badgeStackView.leadingAnchor.constraint(equalTo: self.challengeImageView.leadingAnchor, constant: Metric.newChallengeLabelLeadingMargin),
+      self.badgeStackView.heightAnchor.constraint(equalToConstant: Metric.newChallengeLabelHeight),
+
       self.newChallengeLabel.widthAnchor.constraint(equalToConstant: Metric.newChallengeLabelWidth),
       self.newChallengeLabel.heightAnchor.constraint(equalToConstant: Metric.newChallengeLabelHeight),
 
-      self.hotChallengeLabel.topAnchor.constraint(equalTo: self.challengeImageView.topAnchor, constant: Metric.hotChallengeLabelTopMargin),
-      self.hotChallengeLabel.leadingAnchor.constraint(equalTo: self.newChallengeLabel.trailingAnchor, constant: Metric.hotChallengeLabelLeadingMargin),
       self.hotChallengeLabel.widthAnchor.constraint(equalToConstant: Metric.hotChallengeLabelWidth),
       self.hotChallengeLabel.heightAnchor.constraint(equalToConstant: Metric.hotChallengeLabelHeight),
 

--- a/KnockKnock-iOS/Scenes/Cells/ChallengeDetailCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/ChallengeDetailCell.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import SnapKit
+import KKDSKit
 import Then
 
 final class ChallengeDetailCell: BaseCollectionViewCell {
@@ -62,11 +63,10 @@ final class ChallengeDetailCell: BaseCollectionViewCell {
   func bind(challengeContent: ChallengeDetail.SubContents, isLast: Bool) {
     self.titleLabel.text = challengeContent.title
 
-    self.exampleImageView.image = challengeContent.image
-      .flatMap { URL(string: $0) }
-      .flatMap { try? Data(contentsOf: $0) }
-      .flatMap { UIImage(data: $0) }
-    ?? UIImage(named: "challenge")
+    self.exampleImageView.setImageFromStringUrl(
+      stringUrl: challengeContent.image,
+      defaultImage: KKDS.Image.ic_no_data_60
+    )
 
     self.contentsLabel.setLineHeight(
       content: challengeContent.content,

--- a/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailInteractor.swift
@@ -21,11 +21,13 @@ final class ChallengeDetailInteractor: ChallengeDetailInteractorProtocol {
   var router: ChallengeDetailRouter?
   
   func getChallengeDetail(challengeId: Int) {
+    LoadingIndicator.showLoading()
     self.worker?.getChallengeDetail(
       challengeId: challengeId,
       completionHandler: { challengeDetail in
         self.presenter?.presentChallengeDetail(challengeDetail: challengeDetail)
-      })
+      }
+    )
   }
   
   func shareChallenge(challengeData: ChallengeDetail?) {

--- a/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailPresenter.swift
@@ -18,5 +18,6 @@ final class ChallengeDetailPresenter: ChallengeDetailPresenterProtocol {
 
   func presentChallengeDetail(challengeDetail: ChallengeDetail) {
     self.view?.getChallengeDetail(challengeDetail: challengeDetail)
+    LoadingIndicator.hideLoading()
   }
 }

--- a/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailViewController.swift
@@ -20,13 +20,9 @@ final class ChallengeDetailViewController: BaseViewController<ChallengeDetailVie
   // MARK: - Properties
 
   var interactor: ChallengeDetailInteractorProtocol?
-
+  
   var challengeId: Int = 12
-  var challengeDetail: ChallengeDetail? {
-    didSet {
-      self.containerView.challengeDetailCollectionView.reloadData()
-    }
-  }
+  var challengeDetail: ChallengeDetail?
 
   lazy var backBarButtonItem = UIBarButtonItem(
     image: KKDS.Image.ic_back_24_wh,
@@ -110,6 +106,10 @@ final class ChallengeDetailViewController: BaseViewController<ChallengeDetailVie
 extension ChallengeDetailViewController: ChallengeDetailViewProtocol {
   func getChallengeDetail(challengeDetail: ChallengeDetail) {
     self.challengeDetail = challengeDetail
+    
+    DispatchQueue.main.async {
+      self.containerView.challengeDetailCollectionView.reloadData()
+    }
   }
 }
 
@@ -136,7 +136,7 @@ extension ChallengeDetailViewController: UICollectionViewDataSource {
 
     if let challengeDetail = self.challengeDetail {
       let isLast = challengeDetail.content.subContents.count - 1 == indexPath.item
-      print(isLast)
+
       cell.bind(challengeContent: challengeDetail.content.subContents[indexPath.item], isLast: isLast)
     }
 
@@ -154,6 +154,7 @@ extension ChallengeDetailViewController: UICollectionViewDataSource {
     )
 
     if let challengeDetail = self.challengeDetail {
+
       header.bind(challengeDetail: challengeDetail)
     }
 

--- a/KnockKnock-iOS/Scenes/Challenge/Detail/Views/ChallengeDetailHeaderCollectionReusableView.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Detail/Views/ChallengeDetailHeaderCollectionReusableView.swift
@@ -169,13 +169,17 @@ final class ChallengeDetailHeaderCollectionReusableView: UICollectionReusableVie
 
   private func setParticipantsImageStackView(participants: [ChallengeDetail.Participant]) {
     var images: [String?] = []
-
-    participants.forEach {
-      images.append($0.image)
+    Task {
+      participants.forEach {
+        images.append($0.image)
+      }
+      
+      self.participantImageStackView.removeAllSubViews()
+      
+      await self.participantImageStackView.addParticipantImageViews(images: images)
+      
+      self.setParticipantLabel(count: participants.count)
     }
-    self.participantImageStackView.removeAllSubViews()
-    self.participantImageStackView.addParticipantImageViews(images: images)
-    self.setParticipantLabel(count: participants.count)
   }
 
   private func setParticipantLabel(count: Int) {

--- a/KnockKnock-iOS/Scenes/Challenge/Detail/Views/ChallengeDetailHeaderCollectionReusableView.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Detail/Views/ChallengeDetailHeaderCollectionReusableView.swift
@@ -65,7 +65,6 @@ final class ChallengeDetailHeaderCollectionReusableView: UICollectionReusableVie
 
   private let mainImageView = UIImageView().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
-    $0.image = UIImage(named: "challenge")
   }
 
   private let participantView = UIView().then {
@@ -96,7 +95,6 @@ final class ChallengeDetailHeaderCollectionReusableView: UICollectionReusableVie
   private let titleLabel = UILabel().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
     $0.tintColor = .black
-    $0.text = "#GOGO 챌린지"
     $0.font = .systemFont(ofSize: 22, weight: .bold)
     $0.numberOfLines = 1
     $0.textAlignment = .left
@@ -150,18 +148,18 @@ final class ChallengeDetailHeaderCollectionReusableView: UICollectionReusableVie
     self.waysStackView.subviews.forEach {
       $0.removeFromSuperview()
     }
-    self.mainImageView.image = challengeDetail.content.image
-      .flatMap { URL(string: $0) }
-      .flatMap { try? Data(contentsOf: $0) }
-      .flatMap { UIImage(data: $0) }
-    ?? UIImage(named: "challenge")
+    self.mainImageView.setImageFromStringUrl(
+      stringUrl: challengeDetail.contentImage,
+      defaultImage: KKDS.Image.ic_no_data_60
+    )
     
     self.summaryLabel.setLineHeight(
-      content: challengeDetail.challenge.subTitle,
+      content: challengeDetail.subTitle,
       font: .systemFont(ofSize: 14, weight: .regular)
     )
     self.setParticipantsImageStackView(participants: challengeDetail.participants)
-    self.titleLabel.text = challengeDetail.challenge.title
+    self.setParticipantLabel(count: challengeDetail.participants.count)
+    self.titleLabel.text = challengeDetail.title
     self.setWayStackView(ways: challengeDetail.content.rule)
   }
 
@@ -169,6 +167,7 @@ final class ChallengeDetailHeaderCollectionReusableView: UICollectionReusableVie
 
   private func setParticipantsImageStackView(participants: [ChallengeDetail.Participant]) {
     var images: [String?] = []
+
     Task {
       participants.forEach {
         images.append($0.image)
@@ -177,8 +176,6 @@ final class ChallengeDetailHeaderCollectionReusableView: UICollectionReusableVie
       self.participantImageStackView.removeAllSubViews()
       
       await self.participantImageStackView.addParticipantImageViews(images: images)
-      
-      self.setParticipantLabel(count: participants.count)
     }
   }
 

--- a/KnockKnock-iOS/Scenes/Challenge/Detail/Views/ChallengeDetailView.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Detail/Views/ChallengeDetailView.swift
@@ -44,12 +44,12 @@ class ChallengeDetailView: UIView {
     $0.image = KKDS.Image.ic_bg_gradient_wh
   }
 
-  let participateButton = UIButton().then {
+  let participateButton = KKDSLargeButton().then {
     $0.translatesAutoresizingMaskIntoConstraints = false
     $0.backgroundColor = .green50
     $0.setTitle("챌린지 참여하기", for: .normal)
     $0.titleLabel?.textColor = .white
-    $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
+    $0.titleLabel?.font = .systemFont(ofSize: 15, weight: .medium)
     $0.layer.cornerRadius = 3
   }
 
@@ -80,6 +80,7 @@ class ChallengeDetailView: UIView {
     self.participateButton.snp.makeConstraints {
       $0.bottom.equalTo(self.safeAreaLayoutGuide).offset(Metric.participateButtonBottomMargin)
       $0.leading.trailing.equalTo(self.safeAreaLayoutGuide).inset(Metric.participateButtonLeadingMargin)
+      $0.height.equalTo(Metric.participateButtonHeight)
     }
   }
 


### PR DESCRIPTION
## What is this PR?
- 서버 명세 변경에 따라 데이터 바인딩 로직을 수정하였습니다.

## Changes
- 신규, 인기 게시글을 나타내는 배지를 관리하는 UIStackView를 추가하여 자동 정렬되도록 하였습니다.
- 이미지 변환시 `Data(contentsOf:)` 메소드를 사용하지 않고 `URLSession`을 이용하여 data를 반환하도록 변경 하였습니다.

https://user-images.githubusercontent.com/40792935/216808725-bb3e2144-bf87-4a66-a7c5-1f4d71ffdf7a.mov

## Test Checklist
- none.