### PR TITLE
[FEAT] 피드 등록 후 피드 상세로 전환

### DIFF
--- a/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KnockKnock-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
-        "revision" : "78424be314842833c04bc3bef5b72e85fff99204",
-        "version" : "5.6.4"
+        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
+        "version" : "5.6.2"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "f6b558e3f801f2cac336b04f615ce111fa9ddaa0",
-        "version" : "9.2.1"
+        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
+        "version" : "9.2.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
-        "version" : "7.11.0"
+        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
+        "version" : "7.9.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "5ccda3981422a84186387dbb763ba739178b529c",
-        "version" : "2.3.0"
+        "revision" : "d4289da23e978f37c344ea6a386e5546e2466294",
+        "version" : "2.1.0"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ab3a58b7209a17d781c0d1dbb3e1ff3da306bae8",
-        "version" : "1.20.3"
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
       }
     }
   ],

--- a/KnockKnock-iOS/Entity/Feed/FeedWrite.swift
+++ b/KnockKnock-iOS/Entity/Feed/FeedWrite.swift
@@ -5,7 +5,7 @@
 //  Created by Daye on 2022/12/05.
 //
 
-import UIKit
+import Foundation
 
 // MARK: - 피드 등록
 
@@ -19,7 +19,7 @@ struct FeedWrite {
   let scale: String
   let promotions: String
   let challenges: String
-  let images: [UIImage]
+  let images: [Data?]
 }
 
 /// 피드 등록 api response

--- a/KnockKnock-iOS/Entity/Feed/FeedWrite.swift
+++ b/KnockKnock-iOS/Entity/Feed/FeedWrite.swift
@@ -24,6 +24,5 @@ struct FeedWrite {
 
 /// 피드 등록 api response
 struct FeedWriteDTO: Decodable {
-  let code: Int
-  let message: String
+  let id: Int
 }

--- a/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
@@ -21,5 +21,8 @@ extension Notification.Name {
   static let feedMainRefreshAfterDelete = Notification.Name("feedMainRefreshAfterDelete")
   static let feedListRefreshAfterDelete = Notification.Name("feedListRefreshedAfterDelete")
 
+  static let feedListRefreshAfterWrite = Notification.Name("feedListRefreshAfterWrite")
+  static let feedMainRefreshAfterWrite = Notification.Name("feedMainRefreshAfterWrite")
+
   static let postLikeToggled = Notification.Name("postLikeToggled")
 }

--- a/KnockKnock-iOS/Network/KKRouter.swift
+++ b/KnockKnock-iOS/Network/KKRouter.swift
@@ -321,7 +321,7 @@ enum KKRouter: URLRequestConvertible {
       let scale = feedWriteForm.scale.data(using: .utf8) ?? Data()
       let promotions = feedWriteForm.promotions.data(using: .utf8) ?? Data()
       let challenges = feedWriteForm.challenges.data(using: .utf8) ?? Data()
-      let images = feedWriteForm.images.map { $0.pngData() ?? Data() }
+      let images = feedWriteForm.images
 
       multipartFormData.append(content, withName: "content")
       if let storeName = storeName,
@@ -336,7 +336,12 @@ enum KKRouter: URLRequestConvertible {
       multipartFormData.append(challenges, withName: "challenges")
 
       images.forEach {
-        multipartFormData.append($0, withName: "images", fileName: "\($0).png", mimeType: "image/png")
+        multipartFormData.append(
+          $0 ?? Data(),
+          withName: "images",
+          fileName: "\($0).png",
+          mimeType: "image/png"
+        )
       }
 
       return multipartFormData

--- a/KnockKnock-iOS/Repository/FeedWriteRepository.swift
+++ b/KnockKnock-iOS/Repository/FeedWriteRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol FeedWriteRepositoryProtocol {
   func requestChallengeTitles(completionHandler: @escaping (([ChallengeTitle])) -> Void)
   func requestPromotionList(completionHandler: @escaping ([Promotion]) -> Void)
-  func requestFeedPost(postData: FeedWrite, completionHandler: @escaping () -> Void)
+  func requestFeedPost(postData: FeedWrite, completionHandler: @escaping (Bool) -> Void)
 }
 
 final class FeedWriteRepository: FeedWriteRepositoryProtocol {
@@ -53,15 +53,15 @@ final class FeedWriteRepository: FeedWriteRepositoryProtocol {
 
   func requestFeedPost(
     postData: FeedWrite,
-    completionHandler: @escaping () -> Void
+    completionHandler: @escaping (Bool) -> Void
   ) {
     KKNetworkManager
       .shared
       .upload(
         object: FeedWriteDTO.self,
         router: KKRouter.postFeed(postData: postData),
-        success: { _ in
-          completionHandler()
+        success: { response in
+          completionHandler(response.code == 200)
         },
         failure: { error in
           print(error)

--- a/KnockKnock-iOS/Repository/FeedWriteRepository.swift
+++ b/KnockKnock-iOS/Repository/FeedWriteRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol FeedWriteRepositoryProtocol {
   func requestChallengeTitles(completionHandler: @escaping (([ChallengeTitle])) -> Void)
   func requestPromotionList(completionHandler: @escaping ([Promotion]) -> Void)
-  func requestFeedPost(postData: FeedWrite, completionHandler: @escaping (Bool) -> Void)
+  func requestFeedPost(postData: FeedWrite, completionHandler: @escaping (Int?) -> Void)
 }
 
 final class FeedWriteRepository: FeedWriteRepositoryProtocol {
@@ -53,15 +53,15 @@ final class FeedWriteRepository: FeedWriteRepositoryProtocol {
 
   func requestFeedPost(
     postData: FeedWrite,
-    completionHandler: @escaping (Bool) -> Void
+    completionHandler: @escaping (Int?) -> Void
   ) {
     KKNetworkManager
       .shared
       .upload(
-        object: FeedWriteDTO.self,
+        object: ApiResponseDTO<FeedWriteDTO>.self,
         router: KKRouter.postFeed(postData: postData),
         success: { response in
-          completionHandler(response.code == 200)
+          completionHandler(response.data?.id)
         },
         failure: { error in
           print(error)

--- a/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailRouter.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailRouter.swift
@@ -55,12 +55,17 @@ final class ChallengeDetailRouter: ChallengeDetailRouterProtocol {
   }
 
   func presentToFeedWrite(challengeId: Int) {
-    let feedWriteViewController = UINavigationController(
-      rootViewController: FeedWriteRouter.createFeedWrite(challengeId: challengeId)
-    )
-    feedWriteViewController.modalPresentationStyle = .fullScreen
 
     guard let sourceView = self.view as? UIViewController else { return }
+
+    let feedWriteViewController = UINavigationController(
+      rootViewController: FeedWriteRouter.createFeedWrite(
+        challengeId: challengeId,
+        rootView: sourceView.navigationController
+      )
+    )
+
+    feedWriteViewController.modalPresentationStyle = .fullScreen
 
     sourceView.navigationController?.present(feedWriteViewController, animated: true)
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -40,6 +40,7 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
   
   override func viewDidLoad() {
     super.viewDidLoad()
+
     LoadingIndicator.showLoading()
     
     self.setNavigationBar()
@@ -113,7 +114,7 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
     self.navigationItem.rightBarButtonItem = moreButton
     self.navigationController?.navigationBar.backgroundColor = .white
     self.navigationController?.navigationBar.tintColor = .black
-    self.changeStatusBarBgColor(bgColor: .white)
+    self.changeStatusBarBgColor(bgColor: .clear)
   }
   
   // MARK: - Button Actions

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
@@ -431,14 +431,6 @@ extension FeedListInteractor {
     )
 
     NotificationCenter.default.addObserver(
-      forName: .feedListRefreshAfterWrite,
-      object: nil,
-      queue: nil
-    ) { _ in
-      self.presenter?.reloadFeedList()
-    }
-
-    NotificationCenter.default.addObserver(
       self,
       selector: #selector(self.addCommentNotificationEvent(_:)),
       name: .feedListCommentRefreshAfterAdd,

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
@@ -267,5 +267,13 @@ extension FeedListInteractor {
       name: .feedListRefreshAfterDelete,
       object: nil
     )
+
+    NotificationCenter.default.addObserver(
+      forName: .feedListRefreshAfterWrite,
+      object: nil,
+      queue: nil
+    ) { _ in
+      self.presenter?.reloadFeedList()
+    }
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -11,9 +11,16 @@ protocol FeedMainInteractorProtocol {
   var presenter: FeedMainPresenterProtocol? { get set }
   var worker: FeedMainWorkerProtocol? { get set }
 
-  func fetchFeedMain(currentPage: Int, pageSize: Int, challengeId: Int)
+  func fetchFeedMain(
+    currentPage: Int,
+    pageSize: Int,
+    challengeId: Int
+  )
   func fetchChallengeTitles()
-  func setSelectedStatus(challengeTitles: [ChallengeTitle], selectedIndex: IndexPath)
+  func setSelectedStatus(
+    challengeTitles: [ChallengeTitle],
+    selectedIndex: IndexPath
+  )
 
   func saveSearchKeyword(searchKeyword: [SearchKeyword])
 }
@@ -52,39 +59,54 @@ final class FeedMainInteractor: FeedMainInteractorProtocol {
       challengeId: challengeId,
       completionHandler: { [weak self] data in
 
+        guard let self = self else { return }
+
         if currentPage == 1 {
-          self?.feedData = data
+          self.feedData = data
         } else {
-          self?.feedData?.feeds += data.feeds
-          self?.feedData?.isNext = data.isNext
+          self.feedData?.feeds += data.feeds
+          self.feedData?.isNext = data.isNext
         }
 
-        guard let feedData = self?.feedData else { return }
-        self?.presenter?.presentFeedMain(feed: feedData)
+        guard let feedData = self.feedData else { return }
+        self.presenter?.presentFeedMain(feed: feedData)
       }
     )
   }
 
   func fetchChallengeTitles() {
     self.worker?.fetchChallengeTitles { [weak self] challengeTitle in
+      guard let self = self else { return }
+
       var challengeTitle = challengeTitle
       challengeTitle[0].isSelected = true
 
-      self?.presenter?.presentGetChallengeTitles(challengeTitle: challengeTitle, index: nil)
+      self.presenter?.presentGetChallengeTitles(
+        challengeTitle: challengeTitle,
+        index: nil
+      )
     }
   }
 
-  func setSelectedStatus(challengeTitles: [ChallengeTitle], selectedIndex: IndexPath) {
+  func setSelectedStatus(
+    challengeTitles: [ChallengeTitle],
+    selectedIndex: IndexPath
+  ) {
     var challengeTitles = challengeTitles
 
     for index in 0..<challengeTitles.count {
+
       if index == selectedIndex.item {
         challengeTitles[index].isSelected = true
+
       } else {
         challengeTitles[index].isSelected = false
       }
     }
-    presenter?.presentGetChallengeTitles(challengeTitle: challengeTitles, index: selectedIndex)
+    presenter?.presentGetChallengeTitles(
+      challengeTitle: challengeTitles,
+      index: selectedIndex
+    )
   }
 }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -116,5 +116,13 @@ extension FeedMainInteractor {
       name: .feedMainRefreshAfterDelete,
       object: nil
     )
+
+    NotificationCenter.default.addObserver(
+      forName: .feedMainRefreshAfterWrite,
+      object: nil,
+      queue: nil
+    ) { _ in
+      self.presenter?.reloadFeedMain()
+    }
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
@@ -12,7 +12,7 @@ protocol FeedMainPresenterProtocol {
   
   func presentFeedMain(feed: FeedMain)
   func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?)
-
+  func reloadFeedMain()
 }
 
 final class FeedMainPresenter: FeedMainPresenterProtocol {
@@ -28,5 +28,9 @@ final class FeedMainPresenter: FeedMainPresenterProtocol {
 
   func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?) {
     self.view?.fetchChallengeTitles(challengeTitle: challengeTitle, index: index)
+  }
+
+  func reloadFeedMain() {
+    self.view?.reloadFeedMain()
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainPresenter.swift
@@ -11,7 +11,10 @@ protocol FeedMainPresenterProtocol {
   var view: FeedMainViewProtocol? { get set }
   
   func presentFeedMain(feed: FeedMain)
-  func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?)
+  func presentGetChallengeTitles(
+    challengeTitle: [ChallengeTitle],
+    index: IndexPath?
+  )
   func reloadFeedMain()
 }
 
@@ -26,8 +29,14 @@ final class FeedMainPresenter: FeedMainPresenterProtocol {
     LoadingIndicator.hideLoading()
   }
 
-  func presentGetChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?) {
-    self.view?.fetchChallengeTitles(challengeTitle: challengeTitle, index: index)
+  func presentGetChallengeTitles(
+    challengeTitle: [ChallengeTitle],
+    index: IndexPath?
+  ) {
+    self.view?.fetchChallengeTitles(
+      challengeTitle: challengeTitle,
+      index: index
+    )
   }
 
   func reloadFeedMain() {

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -13,6 +13,7 @@ protocol FeedMainViewProtocol: AnyObject {
   func fetchFeedMain(feed: FeedMain)
   func fetchChallengeTitles(challengeTitle: [ChallengeTitle], index: IndexPath?)
   func fetchSearchLog(searchKeyword: [SearchKeyword])
+  func reloadFeedMain()
 }
 
 final class FeedMainViewController: BaseViewController<FeedMainView> {
@@ -148,6 +149,15 @@ extension FeedMainViewController: FeedMainViewProtocol {
     } else {
       self.containerView.tagCollectionView.reloadData()
     }
+  }
+
+  /// 피드 데이터 re-fatch
+  func reloadFeedMain() {
+    self.interactor?.fetchFeedMain(
+      currentPage: self.currentPage,
+      pageSize: self.pageSize,
+      challengeId: self.challengeId
+    )
   }
 }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -154,7 +154,7 @@ extension FeedMainViewController: FeedMainViewProtocol {
   /// 피드 데이터 re-fatch
   func reloadFeedMain() {
     self.interactor?.fetchFeedMain(
-      currentPage: self.currentPage,
+      currentPage: 1,
       pageSize: self.pageSize,
       challengeId: self.challengeId
     )

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -29,14 +29,9 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
   
   var interactor: FeedMainInteractorProtocol?
   var router: FeedMainRouterProtocol?
-  
-  private var feedMain: FeedMain? {
-    didSet {
-      guard let feedPosts = feedMain?.feeds else { return }
-      self.feedMainPost = feedPosts
-    }
-  }
+
   private var feedMainPost: [FeedMain.Post] = []
+  private var isNext: Bool = false
 
   private var challengeTitles: [ChallengeTitle] = []
   private var searchKeyword: [SearchKeyword] = []
@@ -116,7 +111,8 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
 
 extension FeedMainViewController: FeedMainViewProtocol {
   func fetchFeedMain(feed: FeedMain) {
-    self.feedMain = feed
+    self.feedMainPost = feed.feeds
+    self.isNext = feed.isNext
 
     DispatchQueue.main.async {
       self.containerView.feedCollectionView.reloadData()
@@ -172,6 +168,7 @@ extension FeedMainViewController: UISearchBarDelegate {
 // MARK: - CollectionView DataSource, Delegate
 
 extension FeedMainViewController: UICollectionViewDataSource {
+
   func collectionView(
     _ collectionView: UICollectionView,
     numberOfItemsInSection section: Int
@@ -232,11 +229,7 @@ extension FeedMainViewController: UICollectionViewDataSource {
       for: indexPath
     )
 
-    guard let feedMain = self.feedMain else {
-      return footer
-    }
-
-    footer.viewMoreButton.isHidden = !feedMain.isNext
+    footer.viewMoreButton.isHidden = !self.isNext
     footer.viewMoreButton.addTarget(
       self,
       action: #selector(self.didTapViewMoreButton(_:)),

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -74,10 +74,6 @@ final class FeedMainViewController: BaseViewController<FeedMainView> {
     )
     self.interactor?.fetchChallengeTitles()
   }
-  
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-  }
 
   // MARK: - Configure
   

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainWorker.swift
@@ -31,7 +31,6 @@ final class FeedMainWorker: FeedMainWorkerProtocol {
       ]
     }
     userDefaults.set(keyword, forKey: "searchLog")
-    print("저장완료")
   }
 
   func fetchFeedMain(

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteInteractor.swift
@@ -18,7 +18,7 @@ protocol FeedWriteInteractorProtocol: AnyObject {
   func navigateToShopSearch()
   func navigateToProperty(propertyType: PropertyType)
 
-  func setCurrentText(text: String) 
+  func setCurrentText(text: String)
   func checkEssentialField(imageCount: Int)
   func requestUploadFeed(content: String, images: [UIImage])
 }
@@ -102,12 +102,20 @@ final class FeedWriteInteractor: FeedWriteInteractorProtocol {
         promotions: promotions,
         challenges: challenges,
         images: images
-      ), completionHandler: {
+      ), completionHandler: { isSuccess in
+
         LoadingIndicator.hideLoading()
 
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1, execute: {
-          self.presentFeedWriteCompletedView()
-        })
+        if isSuccess {
+          DispatchQueue.main.asyncAfter(
+            deadline: DispatchTime.now(),
+            execute: {
+              self.presentFeedWriteCompletedView()
+            }
+          )
+        } else {
+          // error
+        }
       }
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteInteractor.swift
@@ -13,7 +13,7 @@ protocol FeedWriteInteractorProtocol: AnyObject {
   var router: FeedWriteRouterProtocol? { get set }
 
   func dismissFeedWriteView()
-  func presentFeedWriteCompletedView()
+  func presentFeedWriteCompletedView(feedId: Int)
   func navigateToShopSearch()
   func navigateToProperty(propertyType: PropertyType)
   func showAlertView(
@@ -48,11 +48,11 @@ final class FeedWriteInteractor: FeedWriteInteractorProtocol {
   // Routing
 
   func dismissFeedWriteView() {
-    self.router?.dismissFeedWriteView()
+    self.router?.dismissFeedWriteView(feedId: nil)
   }
 
-  func presentFeedWriteCompletedView() {
-    self.router?.presenetFeedWriteCompletedView()
+  func presentFeedWriteCompletedView(feedId: Int) {
+    self.router?.presenetFeedWriteCompletedView(feedId: feedId)
   }
 
   func navigateToShopSearch() {
@@ -139,20 +139,22 @@ final class FeedWriteInteractor: FeedWriteInteractorProtocol {
         promotions: promotions,
         challenges: challenges,
         images: images
-      ), completionHandler: { isSuccess in
+      ), completionHandler: { feedId in
+
+        guard let feedId = feedId else {
+          // error
+
+          return
+        }
 
         LoadingIndicator.hideLoading()
 
-        if isSuccess {
-          DispatchQueue.main.asyncAfter(
-            deadline: DispatchTime.now(),
-            execute: {
-              self.presentFeedWriteCompletedView()
-            }
-          )
-        } else {
-          // error
-        }
+        DispatchQueue.main.asyncAfter(
+          deadline: DispatchTime.now(),
+          execute: {
+            self.presentFeedWriteCompletedView(feedId: feedId)
+          }
+        )
       }
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWritePresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWritePresenter.swift
@@ -13,7 +13,6 @@ protocol FeedWritePresenterProtocol: AnyObject {
   func presentSelectedPromotions(promotionList: [Promotion])
   func presentSelectedTags(tagList: [ChallengeTitle])
   func presentShopAddress(address: AddressResponse.Documents)
-  func presentAlertView(isDone: Bool)
 }
 
 final class FeedWritePresenter: FeedWritePresenterProtocol {
@@ -49,7 +48,4 @@ final class FeedWritePresenter: FeedWritePresenterProtocol {
     self.view?.fetchTag(tag: content)
   }
 
-  func presentAlertView(isDone: Bool) {
-    self.view?.showAlertView(isDone: isDone)
-  }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteRouter.swift
@@ -20,6 +20,10 @@ protocol FeedWriteRouterProtocol: AnyObject {
     promotionList: [Promotion]?,
     tagList: [ChallengeTitle]?
   )
+  func showAlertView(
+    message: String,
+    confirmAction: (() -> Void)?
+  )
 }
 
 final class FeedWriteRouter: FeedWriteRouterProtocol {
@@ -48,6 +52,19 @@ final class FeedWriteRouter: FeedWriteRouterProtocol {
     interactor.challengeId = challengeId
 
     return view
+  }
+
+  func showAlertView(
+    message: String,
+    confirmAction: (() -> Void)?
+  ) {
+    guard let sourceView = self.view as? UIViewController else { return }
+    
+    sourceView.showAlert(
+      content: message,
+      isCancelActive: false,
+      confirmActionCompletion: confirmAction
+    )
   }
 
   func navigateToShopSearch() {

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteRouter.swift
@@ -10,10 +10,13 @@ import UIKit
 protocol FeedWriteRouterProtocol: AnyObject {
   var view: FeedWriteViewProtocol? { get set }
 
-  static func createFeedWrite(challengeId: Int?) -> UIViewController
+  static func createFeedWrite(
+    challengeId: Int?,
+    rootView: UINavigationController?
+  ) -> UIViewController
 
-  func dismissFeedWriteView()
-  func presenetFeedWriteCompletedView()
+  func dismissFeedWriteView(feedId: Int?)
+  func presenetFeedWriteCompletedView(feedId: Int)
   func navigateToShopSearch()
   func navigateToProperty(
     propertyType: PropertyType,
@@ -32,8 +35,13 @@ final class FeedWriteRouter: FeedWriteRouterProtocol {
   var propertyDelegate: PropertyDelegate?
 
   weak var view: FeedWriteViewProtocol?
+  private var rootView: UINavigationController?
 
-  static func createFeedWrite(challengeId: Int? = nil) -> UIViewController {
+  static func createFeedWrite(
+    challengeId: Int? = nil,
+    rootView: UINavigationController?
+  ) -> UIViewController {
+
     let view = FeedWriteViewController()
     let interactor = FeedWriteInteractor()
     let presenter = FeedWritePresenter()
@@ -50,6 +58,8 @@ final class FeedWriteRouter: FeedWriteRouterProtocol {
     router.shopSearchDelegate = interactor
     router.propertyDelegate = interactor
     interactor.challengeId = challengeId
+
+    router.rootView = rootView
 
     return view
   }
@@ -96,30 +106,52 @@ final class FeedWriteRouter: FeedWriteRouterProtocol {
     }
   }
 
-  func presenetFeedWriteCompletedView() {
+  func presenetFeedWriteCompletedView(feedId: Int) {
     guard let sourceView = self.view as? UIViewController else { return }
 
-    let feedWriteCompetedViewController = FeedWriteCompletedViewController()
+    let feedWriteCompletedViewController = FeedWriteCompletedViewController()
 
-    feedWriteCompetedViewController.modalPresentationStyle = .overFullScreen
+    feedWriteCompletedViewController.modalPresentationStyle = .overFullScreen
 
     sourceView.navigationController?.present(
-      feedWriteCompetedViewController,
+      feedWriteCompletedViewController,
       animated: true,
       completion: {
+
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2) {
-          feedWriteCompetedViewController.dismiss(
+
+          feedWriteCompletedViewController.dismiss(
             animated: true,
-            completion: self.dismissFeedWriteView
+            completion: {
+              
+              self.dismissFeedWriteView(feedId: feedId)
+            }
           )
         }
       }
     )
   }
 
-  func dismissFeedWriteView() {
-    if let sourceView = self.view as? UIViewController {
+  func dismissFeedWriteView(feedId: Int? = nil) {
+    guard let sourceView = self.view as? UIViewController else { return }
+
+    guard let feedId = feedId else {
       sourceView.dismiss(animated: true)
+      return
     }
+
+    let feedDetailViewController = FeedDetailRouter.createFeedDetail(feedId: feedId)
+    feedDetailViewController.hidesBottomBarWhenPushed = true
+    
+    sourceView.dismiss(
+      animated: true,
+      completion: {
+        
+        self.rootView?.pushViewController(
+          feedDetailViewController,
+          animated: true
+        )
+      }
+    )
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
@@ -169,7 +169,7 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
   }
 
   @objc func doneButtonDidTap(_ sender: UIButton) {
-    self.interactor?.checkEssentialField(imageCount: self.selectedImages.count)
+    self.interactor?.checkEssentialField(image: self.selectedImages.map { $0.pngData() })
   }
 
   // MARK: - ImagePicker
@@ -223,17 +223,19 @@ extension FeedWriteViewController: FeedWriteViewProtocol {
   }
 
   func showAlertView(isDone: Bool) {
-    if isDone {
-      self.showAlert(content: "게시글 등록을 완료 하시겠습니까?", confirmActionCompletion: {
-        LoadingIndicator.showLoading()
-        self.interactor?.requestUploadFeed(
-          content: self.containerView.contentTextView.text,
-          images: self.selectedImages
-        )
-      })
-    } else {
-      self.showAlert(content: "사진, 태그, 프로모션, 내용은 필수 입력 항목입니다.")
-    }
+//    if isDone {
+//      self.showAlert(
+//        content: "게시글 등록을 완료 하시겠습니까?",
+//        confirmActionCompletion: {
+//        LoadingIndicator.showLoading()
+//        self.interactor?.requestUploadFeed(
+//          content: self.containerView.contentTextView.text,
+//          images: self.selectedImages
+//        )
+//      })
+//    } else {
+//      self.showAlert(content: "사진, 태그, 프로모션, 내용은 필수 입력 항목입니다.")
+//    }
   }
 }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteViewController.swift
@@ -17,8 +17,6 @@ protocol FeedWriteViewProtocol: AnyObject {
   func fetchTag(tag: String)
   func fetchPromotion(promotion: String)
   func fetchAddress(address: AddressResponse.Documents)
-
-  func showAlertView(isDone: Bool)
 }
 
 final class FeedWriteViewController: BaseViewController<FeedWriteView> {
@@ -50,18 +48,11 @@ final class FeedWriteViewController: BaseViewController<FeedWriteView> {
     super.viewDidLoad()
   }
 
-  override func viewDidAppear(_ animated: Bool) {
-    self.changeStatusBarBgColor(bgColor: .white)
-  }
-
-  override func viewWillDisappear(_ animated: Bool) {
-    self.changeStatusBarBgColor(bgColor: .clear)
-  }
-
   // MARK: - Configure
 
   override func setupConfigure() {
     self.hideKeyboardWhenTappedAround()
+    self.changeStatusBarBgColor(bgColor: .clear)
 
     self.navigationItem.do {
       $0.title = "새 게시글"
@@ -220,22 +211,6 @@ extension FeedWriteViewController: FeedWriteViewProtocol {
       name: address.placeName,
       address: address.addressName
     )
-  }
-
-  func showAlertView(isDone: Bool) {
-//    if isDone {
-//      self.showAlert(
-//        content: "게시글 등록을 완료 하시겠습니까?",
-//        confirmActionCompletion: {
-//        LoadingIndicator.showLoading()
-//        self.interactor?.requestUploadFeed(
-//          content: self.containerView.contentTextView.text,
-//          images: self.selectedImages
-//        )
-//      })
-//    } else {
-//      self.showAlert(content: "사진, 태그, 프로모션, 내용은 필수 입력 항목입니다.")
-//    }
   }
 }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteWorker.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol FeedWriteWorkerProtocol: AnyObject {
   func uploadFeed(
     postData: FeedWrite,
-    completionHandler: @escaping (Bool) -> Void
+    completionHandler: @escaping (Int?) -> Void
   )
   func checkEssentialField(
     imageCount: Int,
@@ -39,15 +39,14 @@ final class FeedWriteWorker: FeedWriteWorkerProtocol {
 
   func uploadFeed(
     postData: FeedWrite,
-    completionHandler: @escaping (Bool) -> Void
+    completionHandler: @escaping (Int?) -> Void
   ) {
     self.feedWriteRepository.requestFeedPost(
       postData: postData,
-      completionHandler: { isSuccess in
-        if isSuccess {
-          self.postWriteNotificationEvent()
-        }
-        completionHandler(isSuccess)
+      completionHandler: { feedId in
+        
+        self.postWriteNotificationEvent()
+        completionHandler(feedId)
       }
     )
   }

--- a/KnockKnock-iOS/Scenes/Home/HomeViewController.swift
+++ b/KnockKnock-iOS/Scenes/Home/HomeViewController.swift
@@ -47,9 +47,13 @@ final class HomeViewController: BaseViewController<HomeView> {
     self.interactor?.fetchHotpost(challengeId: self.challengeId)
     self.interactor?.fetchChallengeList()
   }
-  
+
   override func viewWillAppear(_ animated: Bool) {
-    self.changeStatusBarBgColor(bgColor: .clear)
+    self.navigationController?.setNavigationBarHidden(true, animated: animated)
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    self.navigationController?.setNavigationBarHidden(false, animated: animated)
   }
 
   // MARK: - Configure

--- a/KnockKnock-iOS/Scenes/MainTabBarController.swift
+++ b/KnockKnock-iOS/Scenes/MainTabBarController.swift
@@ -106,11 +106,15 @@ final class MainTabBarController: UITabBarController {
   }
 
   @objc func postButtonDidTap(_ sender: UIButton) {
-    let post = FeedWriteRouter.createFeedWrite()
-    let postNVC = UINavigationController(rootViewController: post)
-    postNVC.modalPresentationStyle = .fullScreen
+    guard let navigationController = self.selectedViewController as? UINavigationController else { return }
 
-    self.present(postNVC, animated: true)
+    let feedWrite = FeedWriteRouter.createFeedWrite(
+      rootView: navigationController
+    )
+    let feedWriteNVC = UINavigationController(rootViewController: feedWrite)
+    feedWriteNVC.modalPresentationStyle = .overFullScreen
+
+    navigationController.present(feedWriteNVC, animated: true)
   }
 
   private func setMiddleButton() {


### PR DESCRIPTION
## What is this PR?
- 피드 등록 후 등록이 완료 된 게시글을 확인 할 수 있도록 피드 상세로 전환됩니다.
- 게시글이 등록되면 피드 메인이 업데이트 됩니다.

## Changes
- 피드 작성을 `present`한 `presentingViewController`의 `NavigationController`를 주입하여 피드 작성 화면이 `dismiss` 된 후 피드 상세 화면으로 `push` 되도록 하였습니다.

https://user-images.githubusercontent.com/40792935/217234521-fd542215-4161-4ffe-b6a2-54bc22450184.mov

## Test Checklist
- none.