### PR TITLE
[FIX] 챌린지 공유 성공 시 로딩 인디케이터 종료 처리

### DIFF
--- a/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Detail/ChallengeDetailInteractor.swift
@@ -65,6 +65,9 @@ final class ChallengeDetailInteractor: ChallengeDetailInteractorProtocol {
           guard let error = error else { return }
 
           self.router?.presentErrorAlertView(message: error.message)
+        } else {
+          
+          LoadingIndicator.hideLoading()
         }
       }
     )


### PR DESCRIPTION
## What is this PR?
- 챌린지 공유 시 로딩 인디케이터가 종료되지 않는 버그를 수정하였습니다.

## Changes
- 공유 성공/실패 시 인디케이터가 종료되도록 했습니다.

## Test Checklist
- none.