### PR TITLE
[FIX] 피드메인 조회에 사용되는 challenge id 수정

### DIFF
--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -246,12 +246,12 @@ extension FeedMainViewController: UICollectionViewDelegate {
     switch collectionView.tag {
     case CollectionViewTag.tag.rawValue:
       self.interactor?.setSelectedStatus(
-        challengeTitles: challengeTitles,
+        challengeTitles: self.challengeTitles,
         selectedIndex: indexPath
       )
 
       self.feedMainPost = []
-      self.challengeId = indexPath.item
+      self.challengeId = self.challengeTitles[indexPath.item].id
       self.currentPage = 1
       
       self.interactor?.fetchFeedMain(


### PR DESCRIPTION
## What is this PR?
- 챌린지 아이디가 잘못 정의되어 피드메인에서 제대로 필터링 되지 않은 결과가 나오는 문제를 해결하였습니다.

## Changes
- indexPath.item로 설정되어있던 값을 api 응답 값의 챌린지 아이디로 수정하였습니다.

## Test Checklist
- none.