### PR TITLE
[FIX] placeholder가 댓글 텍스트로 인식 되는 문제 개선

### DIFF
--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentViewController.swift
@@ -81,7 +81,7 @@ final class CommentViewController: BaseViewController<CommentView> {
     self.addKeyboardNotification()
     self.hideKeyboardWhenTappedAround()
   }
-  
+
   // MARK: - Keyboard Show & Hide
   
   private func addKeyboardNotification() {
@@ -306,11 +306,13 @@ extension CommentViewController: UITextViewDelegate {
       self.containerView.setCommentComponets(isLoggedIn: self.isLoggedIn)
     }
   }
-  
+
   func textViewDidChange(_ textView: UITextView) {
     let size = CGSize(width: view.frame.width, height: .infinity)
     let estimatedSize = textView.sizeThatFits(size)
-    
+
+    self.containerView.registButton.isEnabled = !textView.text.isEmpty
+
     textView.constraints.forEach { (constraint) in
       if estimatedSize.height <= 60 && constraint.firstAttribute == .height {
         constraint.constant = estimatedSize.height

--- a/KnockKnock-iOS/Scenes/Feed/Comment/Views/CommentView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/Views/CommentView.swift
@@ -123,10 +123,15 @@ class CommentView: UIView {
     }
 
     if self.commentTextView.text == Placeholder.noText ||
-        self.commentTextView.text == Placeholder.noLoggedIn {
+      self.commentTextView.text == Placeholder.noLoggedIn {
+
       self.commentTextView.text = nil
       self.commentTextView.textColor = .black
+
     } else if self.commentTextView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+
+      self.registButton.isEnabled = false
+
       self.commentTextView.text = Placeholder.noText
       self.commentTextView.textColor = .gray50
     }

--- a/KnockKnock-iOS/Scenes/Feed/Comment/Views/CommentView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/Views/CommentView.swift
@@ -125,6 +125,8 @@ class CommentView: UIView {
     if self.commentTextView.text == Placeholder.noText ||
       self.commentTextView.text == Placeholder.noLoggedIn {
 
+      self.registButton.isEnabled = false
+
       self.commentTextView.text = nil
       self.commentTextView.textColor = .black
 


### PR DESCRIPTION
## What is this PR?
- placeholder 내용이 댓글 입력 텍스트로 인식되어 댓글이 등록되는 문제를 해결하였습니다.
- 댓글 입력 창에 입력된 글이 없으면 댓글 버튼이 비활성화 됩니다.

https://user-images.githubusercontent.com/40792935/227472533-7f749407-7d15-412c-98cb-1c4284ce1423.mp4


## Changes
- 댓글 입력 TextView에 placeholder만 입력되어있는 경우 등록 버튼이 비활성화 됩니다.
- `UITextViewDelegate`의 `textViewDidChange` 메소드를 통해 UITextView의 변화를 감지하여 입력된 텍스트가 없으면 등록 버튼이 비활성화 처리되도록 하였습니다.

## Test Checklist
- none.