### PR TITLE
[BUG] 답글 삭제 시 화면에 반영 안되는 이슈 해결

### DIFF
--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentInteractor.swift
@@ -119,7 +119,7 @@ final class CommentInteractor: CommentInteractorProtocol {
 
         guard let self = self else { return }
 
-        self.showErrorAlert(response: response )
+        self.showErrorAlert(response: response)
 
         guard let isSuccess = response?.data else { return }
 

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentWorker.swift
@@ -146,6 +146,11 @@ final class CommentWorker: CommentWorkerProtocol {
               feedId: feedId,
               replyCount: comments[commentIndex].data.replyCnt
             )
+          } else {
+            self.postDeleteNotificationEvent(
+              feedId: feedId,
+              replyCount: 0
+            )
           }
         }
         completionHandler(response)

--- a/KnockKnock-iOS/Scenes/Feed/Comment/CommentWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/Comment/CommentWorker.swift
@@ -134,20 +134,18 @@ final class CommentWorker: CommentWorkerProtocol {
     
     self.commentRepository?.requestDeleteComment(
       commentId: commentId,
-      completionHandler: { response in
+      completionHandler: { [weak self] response in
 
-        if let isSuccess = response?.data {
-          if isSuccess {
+        guard let self = self else { return }
 
-            guard let commentIndex = comments.firstIndex(
-              where: { $0.data.id == commentId }
-            ) else { return }
-
+        if response?.data == true {
+          if let commentIndex = comments.firstIndex(
+            where: { $0.data.id == commentId }
+          ) {
             self.postDeleteNotificationEvent(
               feedId: feedId,
               replyCount: comments[commentIndex].data.replyCnt
             )
-
           }
         }
         completionHandler(response)
@@ -160,11 +158,13 @@ final class CommentWorker: CommentWorkerProtocol {
     commentId: Int
   ) -> [Comment] {
     var comments = comments
-    
+
+    // 댓글 삭제
     if let index = comments.firstIndex(where: { $0.data.id == commentId }) {
       comments[index].data.isDeleted = true
     }
-    
+
+    // 답글 삭제
     for commentIndex in 0..<comments.count {
       if let replyIndex = comments[commentIndex].data.reply?.firstIndex(where: {
         $0.id == commentId

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -318,18 +318,15 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
 
         guard let self = self else { return }
 
-        if let isSuccess = response?.data {
-          if isSuccess {
-
-            guard let commentIndex = comments.firstIndex(
-              where: { $0.data.id == commentId }
-            ) else { return }
+        if response?.data == true {
+          if let commentIndex = comments.firstIndex(
+            where: { $0.data.id == commentId }
+          ) {
 
             self.postCommentDeleteNotificationEvent(
               feedId: feedId,
               replyCount: comments[commentIndex].data.replyCnt
             )
-
           }
         }
         completionHandler(response)

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -327,6 +327,11 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
               feedId: feedId,
               replyCount: comments[commentIndex].data.replyCnt
             )
+          } else {
+            self.postCommentDeleteNotificationEvent(
+              feedId: feedId,
+              replyCount: 0
+            )
           }
         }
         completionHandler(response)


### PR DESCRIPTION
## What is this PR?
- 답글 삭제가 정상적으로 이루어졌는데도 화면에서 사라지지 않는 문제를 해결하였습니다.

## Changes
- 댓글이 삭제 된 경우에 NotificationCenter를 통해 이전 화면의 댓글 개수 카운트를 반영하도록 하는 로직 부분을 수정하였습니다.
  - 삭제 된 댓글이 답글이었던 경우에 댓글의 id를 찾는 부분에서 옵셔널 바인딩이 실패하여 기능이 정상적으로 완료되지 않고 종료되는 문제가 있었습니다.

## Test Checklist
- none.