### PR TITLE
[FIX] 피드 상세 댓글 카운트 반영 안되는 문제 + 댓글 등록 이후 좋아요 버튼 사라짐 

### DIFF
--- a/KnockKnock-iOS/Entity/Feed/Comment.swift
+++ b/KnockKnock-iOS/Entity/Feed/Comment.swift
@@ -87,7 +87,7 @@ extension CommentDTO {
             content: $0.content,
             regDate: $0.regDate,
             isDeleted: $0.isDeleted,
-            isWriter: isWriter
+            isWriter: $0.isWriter
           )
         }
       )

--- a/KnockKnock-iOS/Entity/Feed/Comment.swift
+++ b/KnockKnock-iOS/Entity/Feed/Comment.swift
@@ -45,7 +45,7 @@ struct Comment: Decodable {
     let regDate: String
     var isDeleted: Bool
     let isWriter: Bool
-    let replyCnt: Int
+    var replyCnt: Int
     var reply: [Reply]?
 
     struct Reply: Decodable {

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -241,10 +241,15 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
         guard let isSuccess = response?.data else { return }
 
         if isSuccess {
+
+          // 댓글 삭제
           if let index = self.comments.firstIndex(where: { $0.data.id == commentId }) {
             self.comments[index].data.isDeleted = true
+            self.comments[index].data.replyCnt = 0
+            self.comments[index].data.reply = nil
           }
 
+          // 답글 삭제
           for commentIndex in 0..<self.comments.count {
             if let replyIndex = self.comments[commentIndex].data.reply?.firstIndex(where: {
               $0.id == commentId

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -195,6 +195,7 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
 
     DispatchQueue.main.async {
       self.containerView.setCommentComponets(isLoggedIn: self.isLoggedIn)
+      self.containerView.setLikeButton(isHidden: false)
     }
   }
   
@@ -244,21 +245,22 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
   
   @objc private func keyboardWillShow(_ notification: Notification) {
     self.setCommentsTextViewConstant(isAppearing: true)
-    self.setContainerViewConstant(notification: notification, isAppearing: true)
-    self.containerView.likeButton.isHidden = true
+    self.setContainerViewConstant(
+      notification: notification,
+      isAppearing: true
+    )
+//    self.containerView.likeButton.isHidden = true
+    self.containerView.setLikeButton(isHidden: true)
   }
   
   @objc private func keyboardWillHide(_ notification: Notification) {
     self.setCommentsTextViewConstant(isAppearing: false)
-    self.setContainerViewConstant(notification: notification, isAppearing: false)
+    self.setContainerViewConstant(
+      notification: notification,
+      isAppearing: false
+    )
 
-    if self.containerView.commentTextView.text.isEmpty {
-      self.containerView.likeButton.isHidden = false
-      
-      self.containerView.commentTextView.snp.updateConstraints {
-        $0.leading.equalTo(self.containerView.likeButton.snp.trailing)
-      }
-    }
+    self.containerView.setLikeButton(isHidden: !self.containerView.commentTextView.text.isEmpty)
   }
   
   private func setCommentsTextViewConstant(isAppearing: Bool) {

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -249,7 +249,6 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
       notification: notification,
       isAppearing: true
     )
-//    self.containerView.likeButton.isHidden = true
     self.containerView.setLikeButton(isHidden: true)
   }
   

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/Views/FeedDetailView.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/Views/FeedDetailView.swift
@@ -159,6 +159,16 @@ final class FeedDetailView: UIView {
     }
   }
 
+  func setLikeButton(isHidden: Bool) {
+    self.likeButton.isHidden = isHidden
+
+    if !isHidden {
+      self.commentTextView.snp.updateConstraints {
+        $0.leading.equalTo(self.likeButton.snp.trailing)
+      }
+    }
+  }
+
   // MARK: - Constraints
 
   func setupConstraints() {


### PR DESCRIPTION
## What is this PR?
- 답글이 있는 댓글을 삭제했을 때 헤더부분의 댓글 카운트가 반영되지 않는 이슈를 해결하였습니다.
- 댓글 등록 이후 좋아요 버튼이 다시 나타나도록 수정하였습니다. 

## Changes
- 부모 댓글 삭제시 가지고 있는 답글 데이터를 지우도록 수정하였습니다.
- 댓글 등록 이후 좋아요 버튼의 isHidden 상태를 수정하였습니다.

## Test Checklist
- none.