### PR TITLE
[BUG] 프로필 사진이 미설정 된 경우 기본 이미지로 세팅

### DIFF
--- a/KnockKnock-iOS/Extension-Utilities/UIKit/UIImageView+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/UIKit/UIImageView+Ext.swift
@@ -20,7 +20,10 @@ extension UIImageView {
     stringUrl: String?,
     defaultImage: UIImage
   ) {
-    guard let stringUrl = stringUrl else { return }
+    guard let stringUrl = stringUrl else {
+      self.image = defaultImage
+      return
+    }
 
     ImageCache.default.retrieveImage(
       forKey: stringUrl,
@@ -55,6 +58,7 @@ extension UIImageView {
               return
             }
           }
+
           return
         }
         

--- a/KnockKnock-iOS/Scenes/Cells/LikeCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/LikeCell.swift
@@ -60,7 +60,7 @@ final class LikeCell: BaseCollectionViewCell {
   func setImage(imageUrl: String?) {
     self.profileImageView.setImageFromStringUrl(
       stringUrl: imageUrl,
-      defaultImage: KKDS.Image.ic_like_circle_16
+      defaultImage: KKDS.Image.ic_person_24
     )
   }
   


### PR DESCRIPTION
## What is this PR?
- 프로필 사진이 미설정 된 경우에 스크롤을 움직이거나 좋아요 이벤트가 발생한 후 프로필 사진이 타 사용자의 사진으로 덮어쓰여지는 문제를 해결하였습니다.

- 수정 전

https://user-images.githubusercontent.com/40792935/227757622-c8907093-4998-40e7-bb07-765d98477633.mp4


- 수정 후

https://user-images.githubusercontent.com/40792935/227757628-52934bf1-277d-4e8e-9c63-337a3786e667.mp4

## Changes
- 이미지 url로 부터 이미지를 세팅하는 과정에서 url이 존재하지 않는 경우에 대한 처리가 미비하여 UICollectionView cell 재사용과정에서 사진이 덮어쓰여진 것으로 파악했습니다.
- 이미지 url(Optional String type)이 nil인 경우 기본 이미지로 세팅하도록 수정하였습니다.

## Test Checklist
- none.