### PR TITLE
[FEAT] 로그아웃 시 확인+완료 메세지 alert 노출

### DIFF
--- a/KnockKnock-iOS/Enum/AlertMessage.swift
+++ b/KnockKnock-iOS/Enum/AlertMessage.swift
@@ -11,6 +11,9 @@ enum AlertMessage: String {
   case registerDone = "회원가입에 성공하였습니다."
   case registerFailed = "회원가입에 실패하였습니다."
 
+  case signOutConfirm = "로그아웃 하시겠습니까?"
+  case signOutDone = "성공적으로 로그아웃 처리 되었습니다."
+
   case withdrawConfirm = "계정을 삭제하면 게시글, 좋아요, 댓글 등 모든 활동 정보가 삭제됩니다. 그래도 탈퇴 하시겠습니까?"
   case withdrawDone = "성공적으로 탈퇴 처리 되었습니다."
 

--- a/KnockKnock-iOS/Scenes/My/MyInteractor.swift
+++ b/KnockKnock-iOS/Scenes/My/MyInteractor.swift
@@ -80,6 +80,8 @@ final class MyInteractor: MyInteractorProtocol {
           self.presentAlert(message: AlertMessage.unknownedError.rawValue)
           return
         }
+        
+        self.presentAlert(message: AlertMessage.signOutDone.rawValue)
       }
     )
   }

--- a/KnockKnock-iOS/Scenes/My/MyViewController.swift
+++ b/KnockKnock-iOS/Scenes/My/MyViewController.swift
@@ -108,7 +108,13 @@ final class MyViewController: BaseViewController<MyView> {
 
   @objc
   func signOutButtonDidTap(_ sender: UIButton) {
-    self.interactor?.requestSignOut()
+    self.showAlertView(
+      message: AlertMessage.signOutConfirm.rawValue,
+      isCancelActive: true,
+      confirmAction: {
+        self.interactor?.requestSignOut()
+      }
+    )
   }
 
   @objc


### PR DESCRIPTION
## What is this PR?
- 로그아웃 시도시 확인 메세지를, 성공 시 완료 메세지를 alert를 통해 제공합니다.

https://user-images.githubusercontent.com/40792935/227758551-5b651ee0-56a7-4946-a3d2-d2ae49abeb70.mp4


## Changes
- 로그아웃 시도 이전, 성공 이후에 alertView가 present 되도록 하였습니다.

## Test Checklist
- none.