### PR TITLE
[FEAT] 약관 및 정책 url 수정 + 로딩 인디케이터 수정

### DIFF
--- a/KnockKnock-iOS/Enum/MyType.swift
+++ b/KnockKnock-iOS/Enum/MyType.swift
@@ -32,23 +32,19 @@ enum MyMenuType: String {
 
   case serviceTerms = "서비스 이용약관"
   case privacy = "개인정보 처리방침"
-  case locationService = "위치기반 서비스 이용약관"
   case opensource = "오픈소스 라이선스"
 
   var url: String? {
     switch self {
 
     case .serviceTerms:
-     return "https://glib-brow-cf2.notion.site/KnockKnock-09c388824e12462d8d7a56d09042558c"
+     return "https://glib-brow-cf2.notion.site/KonckKonck-4b9c45bfcdbb41cdbb2a1e1d0075a343"
 
     case .privacy:
       return "https://glib-brow-cf2.notion.site/KnockKnock-09c388824e12462d8d7a56d09042558c"
 
-    case .locationService:
-      return "https://glib-brow-cf2.notion.site/KnockKnock-09c388824e12462d8d7a56d09042558c"
-
     case .opensource:
-      return "https://glib-brow-cf2.notion.site/KnockKnock-09c388824e12462d8d7a56d09042558c"
+      return "https://glib-brow-cf2.notion.site/KnockKnock-41c07a7b6e8c4084a4899485ae28967e"
 
     default:
       return nil

--- a/KnockKnock-iOS/Scenes/My/MyViewController.swift
+++ b/KnockKnock-iOS/Scenes/My/MyViewController.swift
@@ -335,7 +335,6 @@ extension MyViewController: UITableViewDelegate {
 
     case .serviceTerms,
          .privacy,
-         .locationService,
          .opensource:
       self.interactor?.navigateToPolicyView(policyType: menu) 
 

--- a/KnockKnock-iOS/Scenes/My/MyWorker.swift
+++ b/KnockKnock-iOS/Scenes/My/MyWorker.swift
@@ -45,7 +45,6 @@ final class MyWorker: MyWorkerProtocol {
 
     let service = MyItem(title: .serviceTerms, type: .plain)
     let privacy = MyItem(title: .privacy, type: .plain)
-    let location = MyItem(title: .locationService, type: .plain)
     let openSource = MyItem(title: .opensource, type: .plain)
 
     let myInfoSection = MySection(
@@ -58,7 +57,7 @@ final class MyWorker: MyWorkerProtocol {
     )
     let policySection = MySection(
       title: .policy,
-      myItems: [service, privacy, location, openSource]
+      myItems: [service, privacy, openSource]
     )
 
     return [myInfoSection, customerSection, policySection]

--- a/KnockKnock-iOS/Scenes/My/Policy/PolicyViewController.swift
+++ b/KnockKnock-iOS/Scenes/My/Policy/PolicyViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import KKDSKit
+import WebKit
 
 final class PolicyViewController: BaseViewController<PolicyView> {
 
@@ -32,6 +33,8 @@ final class PolicyViewController: BaseViewController<PolicyView> {
       action: #selector(self.backButtonDidTap(_:))
     )
 
+    self.containerView.webView.navigationDelegate = self
+
     self.navigationController?.navigationBar.setDefaultAppearance()
     self.navigationItem.leftBarButtonItem = backButton
   }
@@ -42,6 +45,8 @@ final class PolicyViewController: BaseViewController<PolicyView> {
     self.interactor?.popToMyView()
   }
 }
+
+// MARK: - Policy View Protocol
 
 extension PolicyViewController: PolicyViewProtocol, AlertProtocol {
   func fetchPolicyUrl(policyType: MyMenuType) {
@@ -62,7 +67,7 @@ extension PolicyViewController: PolicyViewProtocol, AlertProtocol {
     DispatchQueue.main.async {
       self.containerView.setWebViewUrl(url: url)
       self.navigationItem.title = policyType.rawValue
-      LoadingIndicator.hideLoading()
+//      LoadingIndicator.hideLoading()
     }
   }
 
@@ -79,5 +84,26 @@ extension PolicyViewController: PolicyViewProtocol, AlertProtocol {
         confirmAction: confirmAction
       )
     }
+  }
+}
+
+// MARK: - Policy View Protocol
+
+extension PolicyViewController: WKNavigationDelegate {
+
+  func webView(
+    _ webView: WKWebView,
+    didFinish navigation: WKNavigation!
+  ) {
+    LoadingIndicator.hideLoading()
+  }
+
+  func webView(
+    _ webView: WKWebView,
+    didFail navigation: WKNavigation!,
+    withError error: Error
+  ) {
+    LoadingIndicator.hideLoading()
+    self.showAlertView(message: AlertMessage.pageLoadFailed.rawValue)
   }
 }

--- a/KnockKnock-iOS/Scenes/My/Policy/PolicyViewController.swift
+++ b/KnockKnock-iOS/Scenes/My/Policy/PolicyViewController.swift
@@ -67,7 +67,6 @@ extension PolicyViewController: PolicyViewProtocol, AlertProtocol {
     DispatchQueue.main.async {
       self.containerView.setWebViewUrl(url: url)
       self.navigationItem.title = policyType.rawValue
-//      LoadingIndicator.hideLoading()
     }
   }
 
@@ -87,7 +86,7 @@ extension PolicyViewController: PolicyViewProtocol, AlertProtocol {
   }
 }
 
-// MARK: - Policy View Protocol
+// MARK: - WKNavigationDelegate
 
 extension PolicyViewController: WKNavigationDelegate {
 

--- a/KnockKnock-iOS/Scenes/My/Policy/Views/PolicyView.swift
+++ b/KnockKnock-iOS/Scenes/My/Policy/Views/PolicyView.swift
@@ -29,7 +29,7 @@ final class PolicyView: UIView {
 
   // MARK: - UIs
 
-  private let webView = WKWebView()
+  let webView = WKWebView()
 
   // MARK: - Initialize
 


### PR DESCRIPTION
## What is this PR?
- 각 약관에 맞는 노션 링크를 연결하였습니다.
- 페이지 로드가 완료되면 로딩 인디케이터가 사라지도록 수정하였습니다.

https://user-images.githubusercontent.com/40792935/227760249-be047dc4-2bb5-40a3-9fad-1ab7707eba0f.mp4


## Changes
- `WKNavigationDelegate`의 `didFinish`, `didFail` 메소드를 이용하여 페이지 로딩 완료 이후 로딩 인디케이터가 사라지도록 하였습니다.
- 실패 시에는 페이지 로드 실패 alert가 나타납니다.
- 이동 될 notion page url을 수정하였습니다.

## Test Checklist
- none.