### PR TITLE
[FEAT] 홈에서 인증스토어/이벤트 선택시 상세보기로 전환

### DIFF
--- a/KnockKnock-iOS/Scenes/Home/HomeViewController.swift
+++ b/KnockKnock-iOS/Scenes/Home/HomeViewController.swift
@@ -225,6 +225,9 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
 
     switch section {
 
+    case .store:
+      self.interactor?.navigateToStoreListView()
+
     case .banner:
 
       let barBannerTarget = self.barBannerList[indexPath.item].targetScreen
@@ -259,6 +262,9 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
       let feedId = self.hotPostList[indexPath.item].postId
 
       self.interactor?.navigateToFeedDetail(feedId: feedId)
+
+    case .event:
+      self.interactor?.navigateToEventPageView()
 
     default:
       break


### PR DESCRIPTION
## What is this PR?
- 홈 화면에서 인증스토어 및 이벤트를 클릭해도 더보기 화면으로 넘어가도록 처리합니다.
  - 기존에는 '더보기>'를 클릭해야만 화면이 넘어갔음

## Changes
- 스토어, 이벤트 섹션의 셀 선택시 더보기 화면으로 넘어가는 메소드를 호출하였습니다.

## Test Checklist
- none.