### PR TITLE
[FEAT] 사용자 차단 기능

### DIFF
--- a/KnockKnock-iOS.xcodeproj/project.pbxproj
+++ b/KnockKnock-iOS.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		61A5EA2328B3B71300A0214D /* StoreListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5EA2228B3B71300A0214D /* StoreListView.swift */; };
 		61A5EA2528B3B72100A0214D /* StoreListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5EA2428B3B72100A0214D /* StoreListViewController.swift */; };
 		61A5EA2728B3BEDC00A0214D /* StoreListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5EA2628B3BEDC00A0214D /* StoreListCell.swift */; };
+		61A6AB6D29D6B22000EB5ADF /* FeedListProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A6AB6C29D6B22000EB5ADF /* FeedListProtocol.swift */; };
 		61A6B7272989174B002A1C57 /* ChallengeSortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A6B7262989174B002A1C57 /* ChallengeSortType.swift */; };
 		61A6B729298D1CF9002A1C57 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 61A6B728298D1CF9002A1C57 /* FirebaseMessaging */; };
 		61A730DF28ED4EBA00C6BD98 /* MyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A730DE28ED4EBA00C6BD98 /* MyViewController.swift */; };
@@ -482,6 +483,7 @@
 		61A5EA2228B3B71300A0214D /* StoreListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListView.swift; sourceTree = "<group>"; };
 		61A5EA2428B3B72100A0214D /* StoreListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListViewController.swift; sourceTree = "<group>"; };
 		61A5EA2628B3BEDC00A0214D /* StoreListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListCell.swift; sourceTree = "<group>"; };
+		61A6AB6C29D6B22000EB5ADF /* FeedListProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedListProtocol.swift; sourceTree = "<group>"; };
 		61A6B7262989174B002A1C57 /* ChallengeSortType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeSortType.swift; sourceTree = "<group>"; };
 		61A730DE28ED4EBA00C6BD98 /* MyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyViewController.swift; sourceTree = "<group>"; };
 		61A730E128ED4ECD00C6BD98 /* MyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyView.swift; sourceTree = "<group>"; };
@@ -906,6 +908,7 @@
 				6143297928687B74008BDCC9 /* FeedListPresenter.swift */,
 				6143297528687B56008BDCC9 /* FeedListWorker.swift */,
 				6143297B28687B7F008BDCC9 /* FeedListRouter.swift */,
+				61A6AB6C29D6B22000EB5ADF /* FeedListProtocol.swift */,
 			);
 			path = FeedList;
 			sourceTree = "<group>";
@@ -1803,6 +1806,7 @@
 				6128A4BF297F6B24005E36F3 /* DeeplinkNavigator.swift in Sources */,
 				61D96D6629A899D1009E2842 /* StoreDetail.swift in Sources */,
 				61BB9DA62976784200728E97 /* HotPostRepository.swift in Sources */,
+				61A6AB6D29D6B22000EB5ADF /* FeedListProtocol.swift in Sources */,
 				618D8B6428BDFD3200828794 /* SearchResultCell.swift in Sources */,
 				611BD4AC27E48B9F007D5C79 /* FeedWritePresenter.swift in Sources */,
 				6135F68F29B478F500727FE6 /* PolicyRouter.swift in Sources */,

--- a/KnockKnock-iOS.xcodeproj/project.pbxproj
+++ b/KnockKnock-iOS.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		61A5EA2528B3B72100A0214D /* StoreListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5EA2428B3B72100A0214D /* StoreListViewController.swift */; };
 		61A5EA2728B3BEDC00A0214D /* StoreListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5EA2628B3BEDC00A0214D /* StoreListCell.swift */; };
 		61A6AB6D29D6B22000EB5ADF /* FeedListProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A6AB6C29D6B22000EB5ADF /* FeedListProtocol.swift */; };
+		61A6AB6F29D907C400EB5ADF /* FeedDeatilProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A6AB6E29D907C400EB5ADF /* FeedDeatilProtocol.swift */; };
 		61A6B7272989174B002A1C57 /* ChallengeSortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A6B7262989174B002A1C57 /* ChallengeSortType.swift */; };
 		61A6B729298D1CF9002A1C57 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 61A6B728298D1CF9002A1C57 /* FirebaseMessaging */; };
 		61A730DF28ED4EBA00C6BD98 /* MyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A730DE28ED4EBA00C6BD98 /* MyViewController.swift */; };
@@ -484,6 +485,7 @@
 		61A5EA2428B3B72100A0214D /* StoreListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListViewController.swift; sourceTree = "<group>"; };
 		61A5EA2628B3BEDC00A0214D /* StoreListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListCell.swift; sourceTree = "<group>"; };
 		61A6AB6C29D6B22000EB5ADF /* FeedListProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedListProtocol.swift; sourceTree = "<group>"; };
+		61A6AB6E29D907C400EB5ADF /* FeedDeatilProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDeatilProtocol.swift; sourceTree = "<group>"; };
 		61A6B7262989174B002A1C57 /* ChallengeSortType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeSortType.swift; sourceTree = "<group>"; };
 		61A730DE28ED4EBA00C6BD98 /* MyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyViewController.swift; sourceTree = "<group>"; };
 		61A730E128ED4ECD00C6BD98 /* MyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyView.swift; sourceTree = "<group>"; };
@@ -1277,6 +1279,7 @@
 				613856C6289554E600BE347E /* FeedDetailWorker.swift */,
 				613856C82895554100BE347E /* FeedDetailRouter.swift */,
 				61AB2E4D28A36E3E00A1AE30 /* LikeDetailViewController.swift */,
+				61A6AB6E29D907C400EB5ADF /* FeedDeatilProtocol.swift */,
 			);
 			path = FeedDetail;
 			sourceTree = "<group>";
@@ -1845,6 +1848,7 @@
 				61D96D8429AB3B44009E2842 /* BottomSheetSize.swift in Sources */,
 				6105079828B4EEA800C1B5CF /* HomeInteractor.swift in Sources */,
 				209B80E32955E8D0003E591C /* KakaoLoginManager.swift in Sources */,
+				61A6AB6F29D907C400EB5ADF /* FeedDeatilProtocol.swift in Sources */,
 				61A0285D2910E66E00943A40 /* SocialType.swift in Sources */,
 				616EB0882890E42F001BD18C /* PostCell.swift in Sources */,
 				61FC60E927B9244D00A51DBC /* AppDelegate.swift in Sources */,

--- a/KnockKnock-iOS/Entity/Feed/FeedList.swift
+++ b/KnockKnock-iOS/Entity/Feed/FeedList.swift
@@ -24,6 +24,7 @@ struct FeedListDTO: Decodable {
     let blogCommentCount: String
     let blogImages: [Image]
     let isWriter: Bool
+    let userId: Int
 
     func toShare() -> FeedShare? {
       
@@ -61,6 +62,7 @@ struct FeedList: Decodable {
     var blogCommentCount: String
     let blogImages: [Image]
     let isWriter: Bool
+    let userId: Int
 
     func toShare() -> FeedShare? {
 
@@ -100,7 +102,8 @@ extension FeedListDTO {
               fileUrl: $0.fileUrl
             )
           },
-          isWriter: $0.isWriter
+          isWriter: $0.isWriter,
+          userId: $0.userId
         )
       },
       isNext: isNext,

--- a/KnockKnock-iOS/Enum/AlertMessage.swift
+++ b/KnockKnock-iOS/Enum/AlertMessage.swift
@@ -43,6 +43,10 @@ enum AlertMessage: String {
   case feedReportDone = "게시글이 신고 되었습니다."
   case feedReportFailed = "게시글 신고에 실패하였습니다."
 
+  case userBlockConfirm = "이 사용자를 차단하시겠습니까? 앞으로 해당 사용자의 활동 내역이 나타나지 않습니다."
+  case userBlockDone = "성공적으로 차단이 완료되었습니다."
+  case userBlockFailed = "차단에 실패하였습니다."
+
   case commentDeleteConfirm = "댓글을 삭제하시겠습니까?"
   case commentDeleteFailed = "댓글 삭제에 실패하였습니다."
   case commentFailed = "댓글 등록에 실패하였습니다."

--- a/KnockKnock-iOS/Enum/BottomSheetOption.swift
+++ b/KnockKnock-iOS/Enum/BottomSheetOption.swift
@@ -15,6 +15,7 @@ enum BottomSheetOption {
   case postReport(Action)
   case postShare
   case postHide(Action)
+  case userBlock(Action)
   case challengeNew
   case challengePopular
 
@@ -34,6 +35,9 @@ enum BottomSheetOption {
 
     case .postHide:
       return "숨기기"
+
+    case .userBlock:
+      return "차단하기"
 
     case .challengeNew:
       return "최신순"
@@ -58,6 +62,9 @@ enum BottomSheetOption {
       return nil
 
     case .postHide(let action):
+      return action
+
+    case .userBlock(let action):
       return action
 
     case .challengeNew,

--- a/KnockKnock-iOS/Enum/BottomSheetSize.swift
+++ b/KnockKnock-iOS/Enum/BottomSheetSize.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 enum BottomSheetSize: CGFloat {
-  case small = 0.85
-  case medium = 0.8
-  case large = 0.3
+  case two = 0.85
+  case three = 0.8
+  case four = 0.75
+  case max = 0.3
 }

--- a/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
@@ -16,8 +16,11 @@ extension Notification.Name {
   static let pushSettingUpdated = Notification.Name("pushSettingUpdated")
 
   // Feed
-  static let feedListRefreshAfterSigned = Notification.Name("feedRefreshAfterSigned")
-  static let feedListRefreshAfterUnsigned = Notification.Name("feedRefreshAfterUnsigned")
+  static let feedListRefreshAfterSigned = Notification.Name("feedListRefreshAfterSigned")
+  static let feedListRefreshAfterUnsigned = Notification.Name("feedListRefreshAfterUnsigned")
+
+  static let feedMainRefreshAfterSigned = Notification.Name("feedMainRefreshAfterSigned")
+  static let feedMainRefreshAfterUnsigned = Notification.Name("feedMainRefreshAfterUnsigned")
 
   static let feedMainRefreshAfterDelete = Notification.Name("feedMainRefreshAfterDelete")
   static let feedListRefreshAfterDelete = Notification.Name("feedListRefreshAfterDelete")

--- a/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
@@ -30,6 +30,8 @@ extension Notification.Name {
 
   static let postLikeToggled = Notification.Name("postLikeToggled")
   static let pushFeedMain = Notification.Name("pushFeed")
+  
+  static let feedListRefreshAfterBlocked = Notification.Name("feedListRefreshAfterBlocked")
 
   // Comment
   static let feedListCommentRefreshAfterDelete = Notification.Name("feedListCommentRefreshAfterDelete")

--- a/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
@@ -32,6 +32,7 @@ extension Notification.Name {
   static let pushFeedMain = Notification.Name("pushFeed")
   
   static let feedListRefreshAfterBlocked = Notification.Name("feedListRefreshAfterBlocked")
+  static let feedMainRefreshAfterBlocked = Notification.Name("feedMainRefreshAfterBlocked")
 
   // Comment
   static let feedListCommentRefreshAfterDelete = Notification.Name("feedListCommentRefreshAfterDelete")

--- a/KnockKnock-iOS/Extension-Utilities/Foundation/String+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/Foundation/String+Ext.swift
@@ -21,7 +21,7 @@ extension String {
 
     guard let data = await self.getDataFromStringUrl() else { return defaultImage }
 
-    let image = UIImage(data: data )
+    let image = UIImage(data: data)
 
     return image?.resizeSquareImage(newWidth: imageWidth) ?? defaultImage
 

--- a/KnockKnock-iOS/Network/KKRouter.swift
+++ b/KnockKnock-iOS/Network/KKRouter.swift
@@ -55,6 +55,7 @@ enum KKRouter: URLRequestConvertible {
   case postHideBlogPost(id: Int)
   case postReportBlogPost(id: Int, reportType: String)
   case deleteFeed(id: Int)
+  case postBlockUser(id: Int)
 
   // Feed Edit
   case putFeed(id: Int, post: FeedEdit)
@@ -91,8 +92,8 @@ enum KKRouter: URLRequestConvertible {
 
     // Account
     case .postSocialLogin,
-        .postSignUp,
-        .postLogOut:
+         .postSignUp,
+         .postLogOut:
       return .post
 
     case .deleteWithdraw:
@@ -105,9 +106,9 @@ enum KKRouter: URLRequestConvertible {
 
       // FeedWrite, Main
     case .getChallengeTitles,
-        .getPromotions,
-        .requestShopAddress,
-        .getFeedMain:
+         .getPromotions,
+         .requestShopAddress,
+         .getFeedMain:
       return .get
 
     case .postFeed:
@@ -115,11 +116,12 @@ enum KKRouter: URLRequestConvertible {
 
       // FeedList, Detail
     case .getFeedBlogPost,
-        .getFeed:
+         .getFeed:
       return .get
 
     case .postHideBlogPost,
-         .postReportBlogPost:
+         .postReportBlogPost,
+         .postBlockUser:
       return .post
 
     case .deleteFeed:
@@ -196,6 +198,7 @@ enum KKRouter: URLRequestConvertible {
     case .deleteFeed(let id): return "feed/\(id)"
     case .postHideBlogPost(let id): return "users/hide/blog-post/\(id)"
     case .postReportBlogPost(let id, _): return "users/report/blog-post/\(id)"
+    case .postBlockUser(let id): return "users/block-user/\(id)"
 
       // Feed Edit
     case .putFeed(let id, _): return "feed/\(id)"
@@ -292,7 +295,8 @@ enum KKRouter: URLRequestConvertible {
 
     case .getFeed,
          .postHideBlogPost,
-         .deleteFeed:
+         .deleteFeed,
+         .postBlockUser:
       return nil
 
       // Feed Edit
@@ -458,6 +462,7 @@ enum KKRouter: URLRequestConvertible {
       case .postFeedLike,
            .postHideBlogPost,
            .postLogOut,
+           .postBlockUser,
            .deleteFeedLike,
            .deleteFeed,
            .deleteWithdraw,

--- a/KnockKnock-iOS/Repository/Feed/FeedDetailRepository.swift
+++ b/KnockKnock-iOS/Repository/Feed/FeedDetailRepository.swift
@@ -20,15 +20,19 @@ protocol FeedDetailRepositoryProtocol {
     feedId: Int,
     completionHandler: @escaping (ApiResponse<FeedDetail>?) -> Void
   )
+
   func requestHidePost(
     feedId: Int,
     completionHandler: @escaping (ApiResponse<Bool>?) -> Void
   )
+
   func requestReportPost(
     feedId: Int,
     reportType: ReportType,
     completionHandler: @escaping (ApiResponse<Bool>?) -> Void
   )
+  
+  func requestBlockUser(userId: Int) async -> ApiResponse<Bool>?
 }
 
 final class FeedDetailRepository: FeedDetailRepositoryProtocol {
@@ -190,5 +194,30 @@ final class FeedDetailRepository: FeedDetailRepositoryProtocol {
           print(error.localizedDescription)
         }
       )
+  }
+
+  func requestBlockUser(userId: Int) async -> ApiResponse<Bool>? {
+
+    do {
+      let result = try await KKNetworkManager
+        .shared
+        .asyncRequest(
+          object: ApiResponse<Bool>.self,
+          router: .postBlockUser(id: userId)
+        )
+
+      guard let data = result.value else { return nil }
+
+      return ApiResponse(
+        code: data.code,
+        message: data.message,
+        data: data.code == 200
+      )
+    } catch {
+
+      print(error.localizedDescription)
+      return nil
+    }
+
   }
 }

--- a/KnockKnock-iOS/Repository/Feed/FeedListRepository.swift
+++ b/KnockKnock-iOS/Repository/Feed/FeedListRepository.swift
@@ -30,6 +30,7 @@ protocol FeedListRepositoryProtocol {
     reportType: ReportType,
     completionHandler: @escaping (ApiResponse<Bool>?) -> Void
   )
+  func requestBlockUser(userId: Int) async -> ApiResponse<Bool>?
 }
 
 final class FeedListRepository: FeedListRepositoryProtocol {
@@ -195,5 +196,30 @@ final class FeedListRepository: FeedListRepositoryProtocol {
           print(error.localizedDescription)
         }
       )
+  }
+
+  func requestBlockUser(userId: Int) async -> ApiResponse<Bool>? {
+
+    do {
+      let result = try await KKNetworkManager
+        .shared
+        .asyncRequest(
+          object: ApiResponse<Bool>.self,
+          router: .postBlockUser(id: userId)
+        )
+
+      guard let data = result.value else { return nil }
+
+      return ApiResponse(
+        code: data.code,
+        message: data.message,
+        data: data.code == 200
+      )
+    } catch {
+
+      print(error.localizedDescription)
+      return nil
+    }
+    
   }
 }

--- a/KnockKnock-iOS/Repository/UserDataManager.swift
+++ b/KnockKnock-iOS/Repository/UserDataManager.swift
@@ -59,8 +59,7 @@ final class UserDataManager: UserDataManagerProtocol {
     self.userDefaultsService.set(value: authInfo.accessToken, forkey: .accessToken)
     self.userDefaultsService.set(value: authInfo.refreshToken, forkey: .refreshToken)
 
-    NotificationCenter.default.post(name: .signInCompleted, object: nil)
-    NotificationCenter.default.post(name: .feedListRefreshAfterSigned, object: nil)
+    self.postSignInEvent()
 
     return true
   }
@@ -68,9 +67,8 @@ final class UserDataManager: UserDataManagerProtocol {
   /// 프로필 수정 시 닉네임 저장
   func saveNickname(nickname: String) {
     self.userDefaultsService.set(value: nickname, forkey: .nickname)
-
-    NotificationCenter.default.post(name: .profileUpdated, object: nil)
-    NotificationCenter.default.post(name: .feedListRefreshAfterSigned, object: nil)
+    
+    self.postEditProfileEvent()
   }
 
   /// 회원 탈퇴 및 로그아웃 시 유저 데이터 삭제
@@ -80,8 +78,7 @@ final class UserDataManager: UserDataManagerProtocol {
     self.userDefaultsService.remove(forkey: .nickname)
     self.userDefaultsService.remove(forkey: .profileImage)
 
-    NotificationCenter.default.post(name: .signOutCompleted, object: nil)
-    NotificationCenter.default.post(name: .feedListRefreshAfterUnsigned, object: nil)
+    self.postSignOutEvent()
   }
 }
 
@@ -93,8 +90,27 @@ extension UserDataManager {
   private func checkTokenIsExisted() -> Bool {
     if userDefaultsService.value(forkey: .accessToken) != nil {
       return true
+
     } else {
       return false
+
     }
+  }
+
+  private func postSignInEvent() {
+    NotificationCenter.default.post(name: .signInCompleted, object: nil)
+    NotificationCenter.default.post(name: .feedListRefreshAfterSigned, object: nil)
+    NotificationCenter.default.post(name: .feedMainRefreshAfterSigned, object: nil)
+  }
+
+  private func postSignOutEvent() {
+    NotificationCenter.default.post(name: .signOutCompleted, object: nil)
+    NotificationCenter.default.post(name: .feedListRefreshAfterUnsigned, object: nil)
+    NotificationCenter.default.post(name: .feedMainRefreshAfterUnsigned, object: nil)
+  }
+
+  private func postEditProfileEvent() {
+    NotificationCenter.default.post(name: .profileUpdated, object: nil)
+    NotificationCenter.default.post(name: .feedListRefreshAfterSigned, object: nil)
   }
 }

--- a/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetInteractor.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetInteractor.swift
@@ -19,7 +19,7 @@ final class BottomSheetInteractor: BottomSheetInteractorProtocol {
   var options: [BottomSheetOption]?
   var districtsType: DistrictsType?
   var districtContent: [String]?
-  var bottomSheetSize: BottomSheetSize = .medium
+  var bottomSheetSize: BottomSheetSize = .three
   var feedData: FeedShare?
 
   // MARK: - Buisiness Logic

--- a/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetViewController.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetViewController.swift
@@ -227,7 +227,7 @@ extension BottomSheetViewController: UITableViewDataSource, UITableViewDelegate 
       case .userBlock:
         DispatchQueue.main.async {
           self.showAlert(
-            message: AlertMessage.feedDeleteConfirm.rawValue,
+            message: AlertMessage.userBlockConfirm.rawValue,
             isCancelActive: true,
             confirmAction: {
               self.interactor?.dismissView(action: option.getAction())

--- a/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetViewController.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheet/BottomSheetViewController.swift
@@ -224,6 +224,17 @@ extension BottomSheetViewController: UITableViewDataSource, UITableViewDelegate 
       case .postShare:
         self.interactor?.sharePost()
 
+      case .userBlock:
+        DispatchQueue.main.async {
+          self.showAlert(
+            message: AlertMessage.feedDeleteConfirm.rawValue,
+            isCancelActive: true,
+            confirmAction: {
+              self.interactor?.dismissView(action: option.getAction())
+            }
+          )
+        }
+
       case .challengeNew:
         self.interactor?.passChallengeSortType(sortType: .new)
 

--- a/KnockKnock-iOS/Scenes/BottomSheet/Views/BottomSheetView.swift
+++ b/KnockKnock-iOS/Scenes/BottomSheet/Views/BottomSheetView.swift
@@ -25,12 +25,12 @@ final class BottomSheetView: UIView {
 
   // MARK: - Properties
 
-  var bottomSheetSize: BottomSheetSize = .medium
+  var bottomSheetSize: BottomSheetSize = .three
 
   let screenHeight = UIDevice.current.heightOfSafeArea(includeBottomInset: true)
 
   lazy var bottomSheetHeight: CGFloat = self.bottomSheetSize.rawValue * self.screenHeight
-  lazy var bottomSheetMinHeight: CGFloat = self.screenHeight * BottomSheetSize.medium.rawValue
+  lazy var bottomSheetMinHeight: CGFloat = self.screenHeight * BottomSheetSize.three.rawValue
   lazy var bottomSheetPanMinTopConstant: CGFloat = self.bottomSheetHeight
   lazy var bottomSheetPanStartingTopConstant: CGFloat = self.bottomSheetPanMinTopConstant
 

--- a/KnockKnock-iOS/Scenes/Cells/PostCommentCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/PostCommentCell.swift
@@ -101,12 +101,10 @@ final class PostCommentCell: BaseCollectionViewCell {
     isLoggedIn: Bool
   ) {
 
-    Task {
-      self.profileImageView.image = await comment.data.image?.getImageFromStringUrl(
-        defaultImage: KKDS.Image.ic_person_24,
-        imageWidth: Metric.profileImageViewWidth
-      )
-    }
+    self.profileImageView.setImageFromStringUrl(
+      stringUrl: comment.data.image,
+      defaultImage: KKDS.Image.ic_person_24
+    )
 
     let reply = comment.data.reply.map {
       $0.filter { !$0.isDeleted }

--- a/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeRouter.swift
+++ b/KnockKnock-iOS/Scenes/Challenge/Main/ChallengeRouter.swift
@@ -50,7 +50,7 @@ final class ChallengeRouter: ChallengeRouterProtocol {
         .challengeNew,
         .challengePopular
       ],
-      bottomSheetSize: .small
+      bottomSheetSize: .two
     )
 
     bottomSheetViewController.modalPresentationStyle = .overFullScreen

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDeatilProtocol.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDeatilProtocol.swift
@@ -34,6 +34,7 @@ protocol FeedDetailInteractorProtocol {
   func requestDelete(feedId: Int)
   func requestHide(feedId: Int)
   func requestReport(feedId: Int)
+  func requestBlockUser(userId: Int)
 
   func fetchAllComments(feedId: Int)
 
@@ -125,6 +126,7 @@ protocol FeedDetailWorkerProtocol {
     reportType: ReportType,
     completionHandler: @escaping (ApiResponse<Bool>?) -> Void
   )
+  func requestBlockUser(userId: Int) async -> ApiResponse<Bool>?
 }
 
 protocol FeedDetailRouterProtocol {

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDeatilProtocol.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDeatilProtocol.swift
@@ -1,0 +1,148 @@
+//
+//  FeedDeatilProtocol.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2023/04/02.
+//
+
+import UIKit
+
+protocol FeedDetailViewProtocol: AnyObject {
+  var interactor: FeedDetailInteractorProtocol? { get set }
+
+  func getFeedDetail(feedDetail: FeedDetail)
+  func getAllCommentsCount(allCommentsCount: Int)
+  func fetchVisibleComments(visibleComments: [Comment])
+  func fetchLikeList(like: [Like.Info])
+  func fetchLikeStatus(isToggle: Bool)
+  func deleteComment()
+  func setLoginStatus(isLoggedIn: Bool)
+
+  func showAlertView(
+    message: String,
+    isCancelActive: Bool?,
+    confirmAction: (() -> Void)?
+  )
+}
+
+protocol FeedDetailInteractorProtocol {
+  var worker: FeedDetailWorkerProtocol? { get set }
+  var presenter: FeedDetailPresenterProtocol? { get set }
+  var router: FeedDetailRouterProtocol? { get set }
+
+  func getFeedDeatil(feedId: Int)
+  func requestDelete(feedId: Int)
+  func requestHide(feedId: Int)
+  func requestReport(feedId: Int)
+
+  func fetchAllComments(feedId: Int)
+
+  func fetchVisibleComments(comments: [Comment])
+  func requestAddComment(comment: AddCommentDTO)
+  func toggleVisibleStatus(commentId: Int)
+  func requestDeleteComment(feedId: Int, commentId: Int)
+
+  func requestLike(feedId: Int)
+  func fetchLikeList(feedId: Int)
+
+  func presentReportView(feedId: Int)
+  func navigateToLikeDetail()
+  func navigateToFeedList()
+  func checkLoginStatus()
+  func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
+    options: [BottomSheetOption],
+    feedData: FeedDetail
+  )
+  func navigateToFeedEdit(feedId: Int)
+}
+
+protocol FeedDetailPresenterProtocol {
+  var view: FeedDetailViewProtocol? { get set }
+
+  func presentFeedDetail(feedDetail: FeedDetail)
+
+  func presentAllCommentsCount(allCommentsCount: Int)
+  func presentVisibleComments(comments: [Comment])
+  func presentDeleteComment()
+
+  func presentLikeList(like: [Like.Info])
+  func presentLikeStatus(isToggle: Bool)
+
+  func presentLoginStatus(isLoggedIn: Bool)
+
+  func presentAlert(
+    message: String,
+    isCancelActive: Bool?,
+    confirmAction: (() -> Void)?
+  )
+}
+
+protocol FeedDetailWorkerProtocol {
+  func getFeedDetail(feedId: Int, completionHandler: @escaping (ApiResponse<FeedDetail>?) -> Void)
+
+  func checkTokenIsValidated() async -> Bool
+
+  func requestLike(
+    isLike: Bool,
+    feedId: Int,
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+
+  func toggleLike(feedDetail: FeedDetail?) -> FeedDetail?
+  func fetchLikeList(
+    feedId: Int,
+    completionHandler: @escaping (ApiResponse<[Like.Info]>?) -> Void
+  )
+
+  func getAllComments(
+    feedId: Int,
+    completionHandler: @escaping (ApiResponse<[Comment]>?) -> Void
+  )
+  func fetchVisibleComments(comments: [Comment]?) -> [Comment]
+
+  func requestAddComment(
+    comment: AddCommentDTO,
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+  func requestDeleteComment(
+    feedId: Int,
+    commentId: Int,
+    comments: [Comment],
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+
+  func requestDeleteFeed(
+    feedId: Int,
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+  func requestHidePost(
+    feedId: Int,
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+  func requestReportFeed(
+    feedId: Int,
+    reportType: ReportType,
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+}
+
+protocol FeedDetailRouterProtocol {
+  var view: FeedDetailViewProtocol? { get set }
+
+  static func createFeedDetail(feedId: Int) -> UIViewController
+
+  func navigateToFeedEdit(feedId: Int)
+  func navigateToLikeDetail(like: [Like.Info])
+  func navigateToLoginView()
+  func navigateToFeedList()
+  func presentReportView(
+    action: (() -> Void)?,
+    reportDelegate: ReportDelegate
+  )
+  func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
+    options: [BottomSheetOption],
+    feedData: FeedShare?
+ )
+}

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -32,6 +32,7 @@ protocol FeedDetailInteractorProtocol {
   func navigateToFeedList()
   func checkLoginStatus()
   func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
     options: [BottomSheetOption],
     feedData: FeedDetail
   )
@@ -380,6 +381,7 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
   }
 
   func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
     options: [BottomSheetOption],
     feedData: FeedDetail
   ) {
@@ -390,6 +392,7 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
 
         await MainActor.run {
           self.router?.presentBottomSheetView(
+            bottomSheetSize: bottomSheetSize,
             options: options,
             feedData: feedData.toShare()
           )

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -7,38 +7,6 @@
 
 import Foundation
 
-protocol FeedDetailInteractorProtocol {
-  var worker: FeedDetailWorkerProtocol? { get set }
-  var presenter: FeedDetailPresenterProtocol? { get set }
-  var router: FeedDetailRouterProtocol? { get set }
-  
-  func getFeedDeatil(feedId: Int)
-  func requestDelete(feedId: Int)
-  func requestHide(feedId: Int)
-  func requestReport(feedId: Int)
-  
-  func fetchAllComments(feedId: Int)
-  
-  func fetchVisibleComments(comments: [Comment])
-  func requestAddComment(comment: AddCommentDTO)
-  func toggleVisibleStatus(commentId: Int)
-  func requestDeleteComment(feedId: Int, commentId: Int)
-  
-  func requestLike(feedId: Int)
-  func fetchLikeList(feedId: Int)
-  
-  func presentReportView(feedId: Int)
-  func navigateToLikeDetail()
-  func navigateToFeedList()
-  func checkLoginStatus()
-  func presentBottomSheetView(
-    bottomSheetSize: BottomSheetSize,
-    options: [BottomSheetOption],
-    feedData: FeedDetail
-  )
-  func navigateToFeedEdit(feedId: Int)
-}
-
 extension FeedDetailInteractor: ReportDelegate {
   func setReportType(reportType: ReportType) {
     self.reportType = reportType

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailInteractor.swift
@@ -7,12 +7,6 @@
 
 import Foundation
 
-extension FeedDetailInteractor: ReportDelegate {
-  func setReportType(reportType: ReportType) {
-    self.reportType = reportType
-  }
-}
-
 final class FeedDetailInteractor: FeedDetailInteractorProtocol {
   var worker: FeedDetailWorkerProtocol?
   var presenter: FeedDetailPresenterProtocol?
@@ -325,6 +319,34 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
     )
   }
 
+  /// 유저 차단하기
+  func requestBlockUser(userId: Int) {
+
+    Task {
+
+      let response = await self.worker?.requestBlockUser(userId: userId)
+
+      await MainActor.run {
+        self.showErrorAlert(response: response)
+      }
+
+      guard let isSuccess = response?.data else { return }
+
+      if isSuccess {
+        self.presentAlert(
+          message: AlertMessage.userBlockDone.rawValue,
+          confirmAction: {
+            self.navigateToFeedList()
+          }
+        )
+
+      } else {
+        self.presentAlert(message: AlertMessage.userBlockFailed.rawValue)
+
+      }
+    }
+  }
+
   // Routing
 
   func navigateToLikeDetail() {
@@ -374,6 +396,8 @@ final class FeedDetailInteractor: FeedDetailInteractorProtocol {
     }
   }
 }
+
+// MARK: - Inner Actions
 
 extension FeedDetailInteractor {
   
@@ -431,5 +455,11 @@ extension FeedDetailInteractor {
       isCancelActive: isCancelActive,
       confirmAction: confirmAction
     )
+  }
+}
+
+extension FeedDetailInteractor: ReportDelegate {
+  func setReportType(reportType: ReportType) {
+    self.reportType = reportType
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailPresenter.swift
@@ -7,27 +7,6 @@
 
 import Foundation
 
-protocol FeedDetailPresenterProtocol {
-  var view: FeedDetailViewProtocol? { get set }
-
-  func presentFeedDetail(feedDetail: FeedDetail)
-
-  func presentAllCommentsCount(allCommentsCount: Int)
-  func presentVisibleComments(comments: [Comment])
-  func presentDeleteComment()
-
-  func presentLikeList(like: [Like.Info])
-  func presentLikeStatus(isToggle: Bool)
-
-  func presentLoginStatus(isLoggedIn: Bool)
-
-  func presentAlert(
-    message: String,
-    isCancelActive: Bool?,
-    confirmAction: (() -> Void)?
-  )
-}
-
 final class FeedDetailPresenter: FeedDetailPresenterProtocol {
   weak var view: FeedDetailViewProtocol?
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
@@ -7,26 +7,6 @@
 
 import UIKit
 
-protocol FeedDetailRouterProtocol {
-  var view: FeedDetailViewProtocol? { get set }
-  
-  static func createFeedDetail(feedId: Int) -> UIViewController
-  
-  func navigateToFeedEdit(feedId: Int)
-  func navigateToLikeDetail(like: [Like.Info])
-  func navigateToLoginView()
-  func navigateToFeedList()
-  func presentReportView(
-    action: (() -> Void)?,
-    reportDelegate: ReportDelegate
-  )
-  func presentBottomSheetView(
-    bottomSheetSize: BottomSheetSize,
-    options: [BottomSheetOption],
-    feedData: FeedShare?
- )
-}
-
 final class FeedDetailRouter: FeedDetailRouterProtocol {
   
   weak var view: FeedDetailViewProtocol?

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailRouter.swift
@@ -21,6 +21,7 @@ protocol FeedDetailRouterProtocol {
     reportDelegate: ReportDelegate
   )
   func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
     options: [BottomSheetOption],
     feedData: FeedShare?
  )
@@ -107,13 +108,14 @@ final class FeedDetailRouter: FeedDetailRouterProtocol {
   }
 
   func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
     options: [BottomSheetOption],
     feedData: FeedShare?
   ) {
     
     guard let bottomSheetViewController = BottomSheetRouter.createBottomSheet(
       options: options,
-      bottomSheetSize: .medium,
+      bottomSheetSize: bottomSheetSize,
       feedData: feedData
     ) as? BottomSheetViewController else { return }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -134,7 +134,7 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
     let hideAcion: (() -> Void)?  = { self.interactor?.requestHide(feedId: feedId) }
     let editAction: (() -> Void)?  = { self.interactor?.navigateToFeedEdit(feedId: feedId) }
     let reportAction: (() -> Void)?  = { self.interactor?.presentReportView(feedId: feedId) }
-    let blockAction: (() -> Void)? = { }
+    let blockAction: (() -> Void)? = { self.interactor?.requestBlockUser(userId: 0) }
 
     var options: [BottomSheetOption] = []
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -10,24 +10,6 @@ import UIKit
 import Then
 import KKDSKit
 
-protocol FeedDetailViewProtocol: AnyObject {
-  var interactor: FeedDetailInteractorProtocol? { get set }
-  
-  func getFeedDetail(feedDetail: FeedDetail)
-  func getAllCommentsCount(allCommentsCount: Int)
-  func fetchVisibleComments(visibleComments: [Comment])
-  func fetchLikeList(like: [Like.Info])
-  func fetchLikeStatus(isToggle: Bool)
-  func deleteComment()
-  func setLoginStatus(isLoggedIn: Bool)
-
-  func showAlertView(
-    message: String,
-    isCancelActive: Bool?,
-    confirmAction: (() -> Void)?
-  )
-}
-
 final class FeedDetailViewController: BaseViewController<FeedDetailView> {
   
   // MARK: - Properties

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -129,12 +129,13 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
     guard let feedDetail = self.feedDetail else { return }
 
     let feedId = feedDetail.feed.id
+    let userId = feedDetail.feed.userId
 
     let deleteAction: (() -> Void)? = { self.interactor?.requestDelete(feedId: feedId) }
     let hideAcion: (() -> Void)?  = { self.interactor?.requestHide(feedId: feedId) }
     let editAction: (() -> Void)?  = { self.interactor?.navigateToFeedEdit(feedId: feedId) }
     let reportAction: (() -> Void)?  = { self.interactor?.presentReportView(feedId: feedId) }
-    let blockAction: (() -> Void)? = { self.interactor?.requestBlockUser(userId: 0) }
+    let blockAction: (() -> Void)? = { self.interactor?.requestBlockUser(userId: userId) }
 
     var options: [BottomSheetOption] = []
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailViewController.swift
@@ -152,6 +152,7 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
     let hideAcion: (() -> Void)?  = { self.interactor?.requestHide(feedId: feedId) }
     let editAction: (() -> Void)?  = { self.interactor?.navigateToFeedEdit(feedId: feedId) }
     let reportAction: (() -> Void)?  = { self.interactor?.presentReportView(feedId: feedId) }
+    let blockAction: (() -> Void)? = { }
 
     var options: [BottomSheetOption] = []
 
@@ -163,12 +164,14 @@ final class FeedDetailViewController: BaseViewController<FeedDetailView> {
       ]
     } else {
       options = [
+        .postShare,
         .postHide(hideAcion),
         .postReport(reportAction),
-        .postShare
+        .userBlock(blockAction)
       ]
     }
     self.interactor?.presentBottomSheetView(
+      bottomSheetSize: feedDetail.feed.isWriter ? .three : .four,
       options: options,
       feedData: feedDetail
     )

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -116,6 +116,19 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
     )
   }
 
+  /// 유저 차단 api call
+  func requestBlockUser(userId: Int) async -> ApiResponse<Bool>? {
+    let response = ApiResponse(code: 200, message: "", data: true)
+
+    if let isSuccess = response.data {
+      if isSuccess {
+        self.postUserBlockedEvent()
+      }
+    }
+
+    return response
+  }
+
   /// 전체 댓글에서 삭제된 댓글, 숨김(접힘) 상태 댓글을 제외하고 보여질 댓글만 필터링
   func fetchVisibleComments(comments: [Comment]?) -> [Comment] {
     var visibleComments: [Comment] = []
@@ -310,6 +323,13 @@ extension FeedDetailWorker {
     NotificationCenter.default.post(
       name: .postLikeToggled,
       object: feedId
+    )
+  }
+
+  private func postUserBlockedEvent() {
+    NotificationCenter.default.post(
+      name: .feedListRefreshAfterBlocked,
+      object: nil
     )
   }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -118,9 +118,9 @@ final class FeedDetailWorker: FeedDetailWorkerProtocol {
 
   /// 유저 차단 api call
   func requestBlockUser(userId: Int) async -> ApiResponse<Bool>? {
-    let response = ApiResponse(code: 200, message: "", data: true)
+    let response = await self.feedDetailRepository.requestBlockUser(userId: userId)
 
-    if let isSuccess = response.data {
+    if let isSuccess = response?.data {
       if isSuccess {
         self.postUserBlockedEvent()
       }
@@ -329,6 +329,11 @@ extension FeedDetailWorker {
   private func postUserBlockedEvent() {
     NotificationCenter.default.post(
       name: .feedListRefreshAfterBlocked,
+      object: nil
+    )
+
+    NotificationCenter.default.post(
+      name: .feedMainRefreshAfterBlocked,
       object: nil
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -7,55 +7,6 @@
 
 import Foundation
 
-protocol FeedDetailWorkerProtocol {
-  func getFeedDetail(feedId: Int, completionHandler: @escaping (ApiResponse<FeedDetail>?) -> Void)
-
-  func checkTokenIsValidated() async -> Bool
-  
-  func requestLike(
-    isLike: Bool,
-    feedId: Int,
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-
-  func toggleLike(feedDetail: FeedDetail?) -> FeedDetail?
-  func fetchLikeList(
-    feedId: Int,
-    completionHandler: @escaping (ApiResponse<[Like.Info]>?) -> Void
-  )
-
-  func getAllComments(
-    feedId: Int,
-    completionHandler: @escaping (ApiResponse<[Comment]>?) -> Void
-  )
-  func fetchVisibleComments(comments: [Comment]?) -> [Comment]
-
-  func requestAddComment(
-    comment: AddCommentDTO,
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-  func requestDeleteComment(
-    feedId: Int,
-    commentId: Int,
-    comments: [Comment],
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-
-  func requestDeleteFeed(
-    feedId: Int,
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-  func requestHidePost(
-    feedId: Int,
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-  func requestReportFeed(
-    feedId: Int,
-    reportType: ReportType,
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-}
-
 final class FeedDetailWorker: FeedDetailWorkerProtocol {
   typealias OnCompletionHandler = (ApiResponse<Bool>?) -> Void
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
@@ -14,7 +14,7 @@ final class FeedListInteractor: FeedListInteractorProtocol {
   var presenter: FeedListPresenterProtocol?
   var worker: FeedListWorkerProtocol?
   var router: FeedListRouterProtocol?
-  
+
   private var feedListData: FeedList?
 
   var reportType: ReportType?
@@ -41,7 +41,7 @@ final class FeedListInteractor: FeedListInteractorProtocol {
     challengeId: Int
   ) {
     LoadingIndicator.showLoading()
-    
+
     self.worker?.fetchFeedList(
       currentPage: currentPage,
       count: pageSize,
@@ -224,6 +224,7 @@ final class FeedListInteractor: FeedListInteractorProtocol {
     )
   }
 
+  /// 유저 차단하기
   func requestBlockUser(userId: Int) {
 
     Task {
@@ -237,7 +238,12 @@ final class FeedListInteractor: FeedListInteractorProtocol {
       guard let isSuccess = response?.data else { return }
 
       if isSuccess {
-        self.presentAlert(message: AlertMessage.userBlockDone.rawValue)
+        self.presentAlert(
+          message: AlertMessage.userBlockDone.rawValue,
+          confirmAction: {
+            self.presenter?.reloadFeedList()
+          }
+        )
 
       } else {
         self.presentAlert(message: AlertMessage.userBlockFailed.rawValue)

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
@@ -12,13 +12,19 @@ protocol FeedListInteractorProtocol {
   var worker: FeedListWorkerProtocol? { get set }
   var router: FeedListRouterProtocol? { get set }
   
-  func fetchFeedList(currentPage: Int, pageSize: Int, feedId: Int, challengeId: Int)
+  func fetchFeedList(
+    currentPage: Int,
+    pageSize: Int,
+    feedId: Int,
+    challengeId: Int
+  )
   func requestDelete(feedId: Int)
   func requestHide(feedId: Int)
   func requestLike(feedId: Int)
   func requestReport(feedId: Int)
 
   func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
     options: [BottomSheetOption],
     feedData: FeedList.Post
   )
@@ -284,6 +290,7 @@ final class FeedListInteractor: FeedListInteractorProtocol {
   }
   
   func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
     options: [BottomSheetOption],
     feedData: FeedList.Post
   ) {
@@ -293,6 +300,7 @@ final class FeedListInteractor: FeedListInteractorProtocol {
 
         await MainActor.run {
           self.router?.presentBottomSheetView(
+            bottomSheetSize: bottomSheetSize,
             options: options,
             feedData: feedData.toShare()
           )

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
@@ -553,6 +553,14 @@ extension FeedListInteractor {
       name: .feedListRefreshAfterEdited,
       object: nil
     )
+
+    NotificationCenter.default.addObserver(
+      forName: .feedListRefreshAfterBlocked,
+      object: nil,
+      queue: nil
+    ) { _ in
+      self.presenter?.reloadFeedList()
+    }
   }
 
   // MARK: - Error

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
@@ -7,40 +7,6 @@
 
 import Foundation
 
-protocol FeedListInteractorProtocol {
-  var presenter: FeedListPresenterProtocol? { get set }
-  var worker: FeedListWorkerProtocol? { get set }
-  var router: FeedListRouterProtocol? { get set }
-  
-  func fetchFeedList(
-    currentPage: Int,
-    pageSize: Int,
-    feedId: Int,
-    challengeId: Int
-  )
-  func requestDelete(feedId: Int)
-  func requestHide(feedId: Int)
-  func requestLike(feedId: Int)
-  func requestReport(feedId: Int)
-
-  func presentBottomSheetView(
-    bottomSheetSize: BottomSheetSize,
-    options: [BottomSheetOption],
-    feedData: FeedList.Post
-  )
-  func presentReportView(feedId: Int)
-  func navigateToFeedEdit(feedId: Int)
-  func navigateToFeedMain()
-  func navigateToFeedDetail(feedId: Int)
-  func navigateToCommentView(feedId: Int)
-}
-
-extension FeedListInteractor: ReportDelegate {
-  func setReportType(reportType: ReportType) {
-    self.reportType = reportType
-  }
-}
-
 final class FeedListInteractor: FeedListInteractorProtocol {
 
   // MARK: - Properties
@@ -312,6 +278,14 @@ final class FeedListInteractor: FeedListInteractorProtocol {
         }
       }
     }
+  }
+}
+
+// MARK: - Report Delegate
+
+extension FeedListInteractor: ReportDelegate {
+  func setReportType(reportType: ReportType) {
+    self.reportType = reportType
   }
 }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
@@ -231,11 +231,14 @@ final class FeedListInteractor: FeedListInteractorProtocol {
 
       let response = await self.worker?.requestBlockUser(userId: userId)
 
-      await MainActor.run {
-        self.showErrorAlert(response: response)
-      }
+      guard let isSuccess = response?.data else {
 
-      guard let isSuccess = response?.data else { return }
+        await MainActor.run {
+          self.showErrorAlert(response: response)
+        }
+        
+        return
+      }
 
       if isSuccess {
         self.presentAlert(

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListInteractor.swift
@@ -128,9 +128,7 @@ final class FeedListInteractor: FeedListInteractorProtocol {
       guard let isLike = self.worker?.checkCurrentLikeState(
         feedList: feedList,
         feedId: feedId
-      ) else {
-        return
-      }
+      ) else { return }
 
       self.worker?.requestLike(
         isLike: isLike,
@@ -191,9 +189,7 @@ final class FeedListInteractor: FeedListInteractorProtocol {
   }
 
   /// 피드 신고하기
-  func requestReport(
-    feedId: Int
-  ) {
+  func requestReport(feedId: Int) {
 
     guard let feedList = self.feedListData else { return }
     guard !feedList.feeds.isEmpty else { return }
@@ -226,6 +222,28 @@ final class FeedListInteractor: FeedListInteractorProtocol {
         }
       }
     )
+  }
+
+  func requestBlockUser(userId: Int) {
+
+    Task {
+
+      let response = await self.worker?.requestBlockUser(userId: userId)
+
+      await MainActor.run {
+        self.showErrorAlert(response: response)
+      }
+
+      guard let isSuccess = response?.data else { return }
+
+      if isSuccess {
+        self.presentAlert(message: AlertMessage.userBlockDone.rawValue)
+
+      } else {
+        self.presentAlert(message: AlertMessage.userBlockFailed.rawValue)
+
+      }
+    }
   }
   
   // Routing

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListPresenter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListPresenter.swift
@@ -7,20 +7,6 @@
 
 import Foundation
 
-protocol FeedListPresenterProtocol {
-  var view: FeedListViewController? { get set }
-
-  func presentFetchFeedList(feedList: FeedList)
-  func presentUpdateFeedList(feedList: FeedList, sections: [IndexPath])
-  func reloadFeedList()
-
-  func presentAlert(
-    message: String,
-    isCancelActive: Bool?,
-    confirmAction: (() -> Void)?
-  )
-}
-
 final class FeedListPresenter: FeedListPresenterProtocol {
   var view: FeedListViewController?
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListProtocol.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListProtocol.swift
@@ -1,0 +1,151 @@
+//
+//  FeedListProtocol.swift
+//  KnockKnock-iOS
+//
+//  Created by Daye on 2023/03/31.
+//
+
+import Foundation
+import UIKit
+
+protocol FeedListViewProtocol: AnyObject {
+  var interactor: FeedListInteractorProtocol? { get set }
+
+  func fetchFeedList(feedList: FeedList)
+  func updateFeedList(
+    feedList: FeedList,
+    sections: [IndexPath]
+  )
+  func reloadFeedList()
+
+  func showAlertView(
+    message: String,
+    isCancelActive: Bool?,
+    confirmAction: (() -> Void)?
+  )
+}
+
+protocol FeedListInteractorProtocol {
+  var presenter: FeedListPresenterProtocol? { get set }
+  var worker: FeedListWorkerProtocol? { get set }
+  var router: FeedListRouterProtocol? { get set }
+
+  func fetchFeedList(
+    currentPage: Int,
+    pageSize: Int,
+    feedId: Int,
+    challengeId: Int
+  )
+  func requestDelete(feedId: Int)
+  func requestHide(feedId: Int)
+  func requestLike(feedId: Int)
+  func requestReport(feedId: Int)
+
+  func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
+    options: [BottomSheetOption],
+    feedData: FeedList.Post
+  )
+  func presentReportView(feedId: Int)
+  func navigateToFeedEdit(feedId: Int)
+  func navigateToFeedMain()
+  func navigateToFeedDetail(feedId: Int)
+  func navigateToCommentView(feedId: Int)
+}
+
+protocol FeedListPresenterProtocol {
+  var view: FeedListViewController? { get set }
+
+  func presentFetchFeedList(feedList: FeedList)
+  func presentUpdateFeedList(feedList: FeedList, sections: [IndexPath])
+  func reloadFeedList()
+
+  func presentAlert(
+    message: String,
+    isCancelActive: Bool?,
+    confirmAction: (() -> Void)?
+  )
+}
+
+protocol FeedListWorkerProtocol {
+  func fetchFeedList(
+    currentPage: Int,
+    count: Int,
+    feedId: Int,
+    challengeId: Int,
+    completionHandler: @escaping (ApiResponse<FeedList>?) -> Void
+  )
+  func requestDeleteFeed(
+    feedId: Int,
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+  func requestLike(
+    isLike: Bool,
+    feedId: Int,
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+  func requestHidePost(
+    feedId: Int,
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+  func requestReportFeed(
+    feedId: Int,
+    reportType: ReportType,
+    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
+  )
+
+  func removePostInFeedList(
+    feeds: FeedList,
+    id: Int
+  ) -> FeedList
+
+  func updatePostInFeedList(
+    feeds: FeedList,
+    feedId: Int,
+    contents: String
+  ) -> FeedList
+
+  func checkTokenIsValidated() async -> Bool
+
+  func checkCurrentLikeState(
+    feedList: [FeedList.Post],
+    feedId: Int
+  ) -> Bool
+
+  func changedSections(
+    feeds: [FeedList.Post],
+    id: Int
+  ) -> [Int]
+
+  func convertLikeFeed(
+    feeds: FeedList,
+    id: Int
+  ) -> FeedList
+
+  func convertComment(
+    feeds: FeedList,
+    id: Int,
+    replyCount: Int?,
+    isAdded: Bool
+  ) -> FeedList
+}
+
+protocol FeedListRouterProtocol {
+  var view: FeedListViewProtocol? { get set }
+  static func createFeedList(feedId: Int, challengeId: Int) -> UIViewController
+
+  func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
+    options: [BottomSheetOption],
+    feedData: FeedShare?
+  )
+  func presentReportView(
+    action: (() -> Void)?,
+    reportDelegate: ReportDelegate
+  )
+  func navigateToFeedEdit(feedId: Int)
+  func navigateToFeedMain()
+  func navigateToFeedDetail(feedId: Int)
+  func navigateToCommentView(feedId: Int)
+  func navigateToLoginView()
+}

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListProtocol.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListProtocol.swift
@@ -5,7 +5,6 @@
 //  Created by Daye on 2023/03/31.
 //
 
-import Foundation
 import UIKit
 
 protocol FeedListViewProtocol: AnyObject {

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListProtocol.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListProtocol.swift
@@ -40,6 +40,7 @@ protocol FeedListInteractorProtocol {
   func requestHide(feedId: Int)
   func requestLike(feedId: Int)
   func requestReport(feedId: Int)
+  func requestBlockUser(userId: Int)
 
   func presentBottomSheetView(
     bottomSheetSize: BottomSheetSize,
@@ -93,6 +94,8 @@ protocol FeedListWorkerProtocol {
     reportType: ReportType,
     completionHandler: @escaping (ApiResponse<Bool>?) -> Void
   )
+
+  func requestBlockUser(userId: Int) async -> ApiResponse<Bool>?
 
   func removePostInFeedList(
     feeds: FeedList,

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListRouter.swift
@@ -12,6 +12,7 @@ protocol FeedListRouterProtocol {
   static func createFeedList(feedId: Int, challengeId: Int) -> UIViewController
   
   func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
     options: [BottomSheetOption],
     feedData: FeedShare?
   )
@@ -118,13 +119,14 @@ final class FeedListRouter: FeedListRouterProtocol {
   }
   
   func presentBottomSheetView(
+    bottomSheetSize: BottomSheetSize,
     options: [BottomSheetOption],
     feedData: FeedShare?
   ) {
-    
+
     guard let bottomSheetViewController = BottomSheetRouter.createBottomSheet(
       options: options,
-      bottomSheetSize: .medium,
+      bottomSheetSize: bottomSheetSize,
       feedData: feedData
     ) as? BottomSheetViewController else { return }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListRouter.swift
@@ -7,26 +7,6 @@
 
 import UIKit
 
-protocol FeedListRouterProtocol {
-  var view: FeedListViewProtocol? { get set }
-  static func createFeedList(feedId: Int, challengeId: Int) -> UIViewController
-  
-  func presentBottomSheetView(
-    bottomSheetSize: BottomSheetSize,
-    options: [BottomSheetOption],
-    feedData: FeedShare?
-  )
-  func presentReportView(
-    action: (() -> Void)?,
-    reportDelegate: ReportDelegate
-  )
-  func navigateToFeedEdit(feedId: Int)
-  func navigateToFeedMain()
-  func navigateToFeedDetail(feedId: Int)
-  func navigateToCommentView(feedId: Int)
-  func navigateToLoginView()
-}
-
 final class FeedListRouter: FeedListRouterProtocol {
   weak var view: FeedListViewProtocol?
   

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
@@ -120,6 +120,7 @@ final class FeedListViewController: BaseViewController<FeedListView> {
     let hideAcion: (() -> Void)?  = { self.interactor?.requestHide(feedId: feedId) }
     let editAction: (() -> Void)?  = { self.interactor?.navigateToFeedEdit(feedId: feedId) }
     let reportAction: (() -> Void)?  = { self.interactor?.presentReportView(feedId: feedId) }
+    let blockAction: (() -> Void)? = { }
 
     var options: [BottomSheetOption] = []
 
@@ -131,13 +132,15 @@ final class FeedListViewController: BaseViewController<FeedListView> {
       ]
     } else {
       options = [
+        .postShare,
         .postHide(hideAcion),
         .postReport(reportAction),
-        .postShare
+        .userBlock(blockAction)
       ]
     }
 
     self.interactor?.presentBottomSheetView(
+      bottomSheetSize: isMyPost ? .three : .four,
       options: options,
       feedData: self.feedListPost[sender.tag]
     )

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
@@ -98,7 +98,7 @@ final class FeedListViewController: BaseViewController<FeedListView> {
     
     let isMyPost = self.feedListPost[sender.tag].isWriter
     let feedId = self.feedListPost[sender.tag].id
-    let userId = 10 // change needed
+    let userId = self.feedListPost[sender.tag].userId
 
     let deleteAction: (() -> Void)? = { self.interactor?.requestDelete(feedId: feedId) }
     let hideAcion: (() -> Void)?  = { self.interactor?.requestHide(feedId: feedId) }
@@ -312,6 +312,8 @@ extension FeedListViewController: FeedListViewProtocol, AlertProtocol {
 
   /// 로그인/로그아웃, 유저 차단 시 피드 데이터 re-fatch & reload
   func reloadFeedList() {
+    self.feedListPost = []
+
     self.interactor?.fetchFeedList(
       currentPage: 1,
       pageSize: self.pageSize,

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
@@ -98,12 +98,13 @@ final class FeedListViewController: BaseViewController<FeedListView> {
     
     let isMyPost = self.feedListPost[sender.tag].isWriter
     let feedId = self.feedListPost[sender.tag].id
+    let userId = 10 // change needed
 
     let deleteAction: (() -> Void)? = { self.interactor?.requestDelete(feedId: feedId) }
     let hideAcion: (() -> Void)?  = { self.interactor?.requestHide(feedId: feedId) }
     let editAction: (() -> Void)?  = { self.interactor?.navigateToFeedEdit(feedId: feedId) }
     let reportAction: (() -> Void)?  = { self.interactor?.presentReportView(feedId: feedId) }
-    let blockAction: (() -> Void)? = { }
+    let blockAction: (() -> Void)? = { self.interactor?.requestBlockUser(userId: userId) }
 
     var options: [BottomSheetOption] = []
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
@@ -10,23 +10,6 @@ import UIKit
 import Then
 import KKDSKit
 
-protocol FeedListViewProtocol: AnyObject {
-  var interactor: FeedListInteractorProtocol? { get set }
-  
-  func fetchFeedList(feedList: FeedList)
-  func updateFeedList(
-    feedList: FeedList,
-    sections: [IndexPath]
-  )
-  func reloadFeedList()
-  
-  func showAlertView(
-    message: String,
-    isCancelActive: Bool?,
-    confirmAction: (() -> Void)?
-  )
-}
-
 final class FeedListViewController: BaseViewController<FeedListView> {
   
   // MARK: - Properties

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListViewController.swift
@@ -310,10 +310,10 @@ extension FeedListViewController: FeedListViewProtocol, AlertProtocol {
     }
   }
 
-  /// 로그인/로그아웃 시 피드 데이터 re-fatch & reload
+  /// 로그인/로그아웃, 유저 차단 시 피드 데이터 re-fatch & reload
   func reloadFeedList() {
     self.interactor?.fetchFeedList(
-      currentPage: self.currentPage,
+      currentPage: 1,
       pageSize: self.pageSize,
       feedId: self.feedId,
       challengeId: self.challengeId

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -64,7 +64,7 @@ final class FeedListWorker: FeedListWorkerProtocol {
 
   /// 유저 차단 api call
   func requestBlockUser(userId: Int) async -> ApiResponse<Bool>? {
-    return ApiResponse(code: 200, message: "", data: true)
+    return await self.feedListRepository.requestBlockUser(userId: userId)
   }
 
   /// 이미 조회 된 피드 리스트 내에서 게시글 삭제하기

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -64,7 +64,15 @@ final class FeedListWorker: FeedListWorkerProtocol {
 
   /// 유저 차단 api call
   func requestBlockUser(userId: Int) async -> ApiResponse<Bool>? {
-    return await self.feedListRepository.requestBlockUser(userId: userId)
+    let response = await self.feedListRepository.requestBlockUser(userId: userId)
+
+    if let isSuccess = response?.data {
+      if isSuccess {
+        self.postUserBlockedEvent()
+      }
+    }
+
+    return response
   }
 
   /// 이미 조회 된 피드 리스트 내에서 게시글 삭제하기
@@ -332,6 +340,13 @@ extension FeedListWorker {
     NotificationCenter.default.post(
       name: .feedMainRefreshAfterDelete,
       object: feedId
+    )
+  }
+
+  private func postUserBlockedEvent() {
+    NotificationCenter.default.post(
+      name: .feedMainRefreshAfterBlocked,
+      object: nil
     )
   }
 }

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -62,6 +62,10 @@ final class FeedListWorker: FeedListWorkerProtocol {
     )
   }
 
+  func requestBlockUser(userId: Int) async -> ApiResponse<Bool>? {
+    return ApiResponse(code: 200, message: "", data: true)
+  }
+
   /// 이미 조회 된 피드 리스트 내에서 게시글 삭제하기
   ///
   /// - Parameters:

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -62,6 +62,7 @@ final class FeedListWorker: FeedListWorkerProtocol {
     )
   }
 
+  /// 유저 차단 api call
   func requestBlockUser(userId: Int) async -> ApiResponse<Bool>? {
     return ApiResponse(code: 200, message: "", data: true)
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -7,68 +7,6 @@
 
 import Foundation
 
-protocol FeedListWorkerProtocol {
-  func fetchFeedList(
-    currentPage: Int,
-    count: Int,
-    feedId: Int,
-    challengeId: Int,
-    completionHandler: @escaping (ApiResponse<FeedList>?) -> Void
-  )
-  func requestDeleteFeed(
-    feedId: Int,
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-  func requestLike(
-    isLike: Bool,
-    feedId: Int,
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-  func requestHidePost(
-    feedId: Int,
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-  func requestReportFeed(
-    feedId: Int,
-    reportType: ReportType,
-    completionHandler: @escaping (ApiResponse<Bool>?) -> Void
-  )
-  func removePostInFeedList(
-    feeds: FeedList,
-    id: Int
-  ) -> FeedList
-  
-  func updatePostInFeedList(
-    feeds: FeedList,
-    feedId: Int,
-    contents: String
-  ) -> FeedList
-  
-  func checkTokenIsValidated() async -> Bool
-  
-  func checkCurrentLikeState(
-    feedList: [FeedList.Post],
-    feedId: Int
-  ) -> Bool
-  
-  func changedSections(
-    feeds: [FeedList.Post],
-    id: Int
-  ) -> [Int]
-  
-  func convertLikeFeed(
-    feeds: FeedList,
-    id: Int
-  ) -> FeedList
-
-  func convertComment(
-    feeds: FeedList,
-    id: Int,
-    replyCount: Int?,
-    isAdded: Bool
-  ) -> FeedList
-}
-
 final class FeedListWorker: FeedListWorkerProtocol {
   typealias OnCompletionHandler = (ApiResponse<Bool>?) -> Void
   

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -179,6 +179,14 @@ extension FeedMainInteractor {
     ) { _ in
       self.presenter?.reloadFeedMain()
     }
+
+    NotificationCenter.default.addObserver(
+      forName: .feedMainRefreshAfterBlocked,
+      object: nil,
+      queue: nil
+    ) { _ in
+      self.presenter?.reloadFeedMain()
+    }
   }
 
   // MARK: - Error

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainInteractor.swift
@@ -187,6 +187,22 @@ extension FeedMainInteractor {
     ) { _ in
       self.presenter?.reloadFeedMain()
     }
+
+    NotificationCenter.default.addObserver(
+      forName: .feedMainRefreshAfterSigned,
+      object: nil,
+      queue: nil
+    ) { _ in
+      self.presenter?.reloadFeedMain()
+    }
+
+    NotificationCenter.default.addObserver(
+      forName: .feedMainRefreshAfterUnsigned,
+      object: nil,
+      queue: nil
+    ) { _ in
+      self.presenter?.reloadFeedMain()
+    }
   }
 
   // MARK: - Error

--- a/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedMain/FeedMainViewController.swift
@@ -149,6 +149,8 @@ extension FeedMainViewController: FeedMainViewProtocol, AlertProtocol {
 
   /// 피드 데이터 re-fatch
   func reloadFeedMain() {
+    self.feedMainPost = []
+    
     self.interactor?.fetchFeedMain(
       currentPage: 1,
       pageSize: self.pageSize,

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/shopSearch/ShopSearchRouter.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/shopSearch/ShopSearchRouter.swift
@@ -75,7 +75,7 @@ final class ShopSearchRouter: ShopSearchRouterProtocol {
       districtSelectDelegate: self.districtSelectDelegate,
       districtsType: districtsType,
       districtsContent: content,
-      bottomSheetSize: .large
+      bottomSheetSize: .max
     ) as? BottomSheetViewController else { return }
     
     bottomSheetViewController.modalPresentationStyle = .overFullScreen

--- a/KnockKnock-iOS/Scenes/My/MyWorker.swift
+++ b/KnockKnock-iOS/Scenes/My/MyWorker.swift
@@ -97,9 +97,12 @@ final class MyWorker: MyWorkerProtocol {
   ) {
     self.accountManager?.signOut(
       completionHandler: { [weak self] response in
+
+        guard let self = self else { return }
+
         if let isSuccess = response?.data {
           if isSuccess {
-            self?.userDataManager?.removeAllUserInfo()
+            self.userDataManager?.removeAllUserInfo()
           }
         }
         completionHandler(response)
@@ -112,9 +115,12 @@ final class MyWorker: MyWorkerProtocol {
   ) {
     self.accountManager?.withdraw(
       completionHandler: { [weak self] response in
+
+        guard let self = self else { return }
+
         if let isSuccess = response?.data {
           if isSuccess {
-            self?.userDataManager?.removeAllUserInfo()
+            self.userDataManager?.removeAllUserInfo()
           }
         }
         completionHandler(response)

--- a/KnockKnock-iOS/Utils/LodingIndicator.swift
+++ b/KnockKnock-iOS/Utils/LodingIndicator.swift
@@ -16,32 +16,36 @@ final class LoadingIndicator {
   private var showTime: DispatchTime?
 
   static func showLoading() {
-    guard let window = UIApplication.shared.windows.last else { return }
-    var loadingIndicatorView = LottieAnimationView(name: "zero_waste_loading")
+    DispatchQueue.main.async {
+      guard let window = UIApplication.shared.windows.last else { return }
 
-    if let existedView = window.subviews.first(where: {
-      $0 is LottieAnimationView
-    }) as? LottieAnimationView {
-      loadingIndicatorView = existedView
-    } else {
-      shared.showTime = DispatchTime.now()
+      var loadingIndicatorView = LottieAnimationView(name: "zero_waste_loading")
 
-      let backgroundView = UIView().then {
-        $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.5)
-        $0.frame = window.frame
+      if let existedView = window.subviews.first(where: {
+        $0 is LottieAnimationView
+      }) as? LottieAnimationView {
+        loadingIndicatorView = existedView
+      } else {
+        shared.showTime = DispatchTime.now()
+
+        let backgroundView = UIView().then {
+          $0.backgroundColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.5)
+          $0.frame = window.frame
+        }
+        loadingIndicatorView.frame = CGRect(x: 0, y: 0, width: 120, height: 120)
+        loadingIndicatorView.center = window.center
+
+        window.backgroundColor = .clear
+        window.addSubview(backgroundView)
+        window.addSubview(loadingIndicatorView)
+
+        shared.backgroundView = backgroundView
       }
-      loadingIndicatorView.frame = CGRect(x: 0, y: 0, width: 120, height: 120)
-      loadingIndicatorView.center = window.center
+      loadingIndicatorView.contentMode = .scaleAspectFit
+      loadingIndicatorView.play()
+      loadingIndicatorView.loopMode = .loop
 
-      window.backgroundColor = .clear
-      window.addSubview(backgroundView)
-      window.addSubview(loadingIndicatorView)
-
-      shared.backgroundView = backgroundView
     }
-    loadingIndicatorView.contentMode = .scaleAspectFit
-    loadingIndicatorView.play()
-    loadingIndicatorView.loopMode = .loop
   }
 
   static func hideLoading() {


### PR DESCRIPTION
## What is this PR?
- 특정 사용자를 차단 할 수 있는 기능을 작성하였습니다.
  - 차단 이후에는 해당 사용자에 대한 게시글, 댓글, 좋아요 기록을 볼 수 없습니다.

https://user-images.githubusercontent.com/40792935/230031665-a5581cc8-c651-4bf9-860d-959a6fe65f82.mp4


https://user-images.githubusercontent.com/40792935/230031686-ba4836d9-5ae2-4107-80f0-8ba829937792.mp4


https://user-images.githubusercontent.com/40792935/230031695-857b54d4-f997-4735-9eef-10b3ed2dae2b.mp4

- 차단 전/후
<img width="300" alt="Untitled" src="https://user-images.githubusercontent.com/40792935/230031651-c421c9d9-0c91-4d4e-9272-2175599f6030.png"> <img width="300" alt="Untitled" src="https://user-images.githubusercontent.com/40792935/230031622-56e547a3-4371-4881-85fd-dc3a250e11ab.png">


## Changes
- userId를 이용해 사용자 차단 api를 호출합니다.
- 차단 성공시 데이터를 다시 불러와 화면을 reload 합니다.
- NotificationCenter를 이용해 이전 화면도 데이터를 re-fetch 처리하도록 하였습니다. 

- 피드 상세 댓글에서 답글을 접고 펼칠 때 이미지 로드가 완전하지 않은 버그를 수정하였습니다.
  -  프로필 이미지 세팅을 kingfisher를 사용하도록 수정하였습니다.


## Test Checklist
- none.