### PR TITLE
[FEAT] 홈 화면 인기게시글 섹션 리로드

### DIFF
--- a/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
+++ b/KnockKnock-iOS/Extension-Utilities/Foundation/Notification+Ext.swift
@@ -15,6 +15,9 @@ extension Notification.Name {
   static let profileUpdated = Notification.Name("profileUpdated")
   static let pushSettingUpdated = Notification.Name("pushSettingUpdated")
 
+  // Home
+  static let homePopularPostRefresh = Notification.Name("homePopularPostRefresh")
+
   // Feed
   static let feedListRefreshAfterSigned = Notification.Name("feedListRefreshAfterSigned")
   static let feedListRefreshAfterUnsigned = Notification.Name("feedListRefreshAfterUnsigned")

--- a/KnockKnock-iOS/Scenes/Cells/Home/PopularPostCell.swift
+++ b/KnockKnock-iOS/Scenes/Cells/Home/PopularPostCell.swift
@@ -44,7 +44,10 @@ final class PopularPostCell: BaseCollectionViewCell {
   // MARK: - Bind
 
   func bind(data: HotPost) {
-    self.thumbnailImageView.setImageFromStringUrl(stringUrl: data.fileUrl, defaultImage: KKDS.Image.ic_no_data_60)
+    self.thumbnailImageView.setImageFromStringUrl(
+      stringUrl: data.fileUrl,
+      defaultImage: KKDS.Image.ic_no_data_60
+    )
     self.nickNameLabel.text = "@\(data.nickname)"
   }
 

--- a/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedDetail/FeedDetailWorker.swift
@@ -317,6 +317,11 @@ extension FeedDetailWorker {
       name: .feedMainRefreshAfterDelete,
       object: feedId
     )
+
+    NotificationCenter.default.post(
+      name: .homePopularPostRefresh,
+      object: nil
+    )
   }
 
   private func postLikeNotificationEvent(feedId: Int) {
@@ -334,6 +339,11 @@ extension FeedDetailWorker {
 
     NotificationCenter.default.post(
       name: .feedMainRefreshAfterBlocked,
+      object: nil
+    )
+
+    NotificationCenter.default.post(
+      name: .homePopularPostRefresh,
       object: nil
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedList/FeedListWorker.swift
@@ -341,11 +341,21 @@ extension FeedListWorker {
       name: .feedMainRefreshAfterDelete,
       object: feedId
     )
+    
+    NotificationCenter.default.post(
+      name: .homePopularPostRefresh,
+      object: nil
+    )
   }
 
   private func postUserBlockedEvent() {
     NotificationCenter.default.post(
       name: .feedMainRefreshAfterBlocked,
+      object: nil
+    )
+
+    NotificationCenter.default.post(
+      name: .homePopularPostRefresh,
       object: nil
     )
   }

--- a/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteWorker.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedWrite/FeedWriteWorker.swift
@@ -114,5 +114,10 @@ extension FeedWriteWorker {
       name: .feedMainRefreshAfterWrite,
       object: nil
     )
+    
+    NotificationCenter.default.post(
+      name: .homePopularPostRefresh,
+      object: nil
+    )
   }
 }

--- a/KnockKnock-iOS/Scenes/Home/HomeInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Home/HomeInteractor.swift
@@ -40,6 +40,13 @@ final class HomeInteractor: HomeInteractorProtocol {
   var router: HomeRouterProtocol?
 
   var hotPostList: [HotPost] = []
+  private var challengeId = 0
+
+  // MARK: - Initialize
+
+  init() {
+    self.setNotification()
+  }
 
   // Buisiness logic
 
@@ -142,17 +149,22 @@ final class HomeInteractor: HomeInteractorProtocol {
     }
   }
 
-  func setSelectedStatus(challengeList: [ChallengeTitle], selectedIndex: IndexPath) {
+  func setSelectedStatus(
+    challengeList: [ChallengeTitle],
+    selectedIndex: IndexPath
+  ) {
     var challenges = challengeList
 
+    self.challengeId = challenges[selectedIndex.item].id
+
     for index in 0..<challenges.count {
-      if index == selectedIndex.item {
-        challenges[index].isSelected = true
-      } else {
-        challenges[index].isSelected = false
-      }
+        challenges[index].isSelected = index == selectedIndex.item
     }
-    presenter?.presentChallengeList(challengeList: challenges, index: selectedIndex)
+
+    presenter?.presentChallengeList(
+      challengeList: challenges,
+      index: selectedIndex
+    )
   }
 
   // Routing
@@ -179,11 +191,11 @@ final class HomeInteractor: HomeInteractorProtocol {
   }
 }
 
-extension HomeInteractorProtocol {
+extension HomeInteractor {
 
   // MARK: - Error
 
-  func showErrorAlert<T>(response: ApiResponse<T>?) {
+  private func showErrorAlert<T>(response: ApiResponse<T>?) {
 
     guard let response = response else {
 
@@ -208,6 +220,18 @@ extension HomeInteractorProtocol {
         confirmAction: nil
       )
       return
+    }
+  }
+
+  // MARK: - NotificationCenter
+
+  private func setNotification() {
+    NotificationCenter.default.addObserver(
+      forName: .homePopularPostRefresh,
+      object: nil,
+      queue: nil
+    ) { _ in
+      self.fetchHotpost(challengeId: self.challengeId)
     }
   }
 }


### PR DESCRIPTION
## What is this PR?
- 피드에서 글 작성/신고/숨김/삭제 또는 사용자 차단 홈 화면의 인기 게시글 섹션이 리로드 되도록 처리하였습니다.

https://user-images.githubusercontent.com/40792935/230320059-c31bbcfb-9e9e-44a5-9ede-8c5ff7368922.mp4


## Changes
- NotificationCenter를 이용하여 이벤트를 전달하였습니다.
- 직전에 선택했던 challengeId를 Interactor에서 저장하고 있다가 데이터 패치 시 사용합니다.

## Test Checklist
- none.