### PR TITLE
[FIX] 피드 수정 완료 후 화면 전환

### DIFF
--- a/KnockKnock-iOS/Scenes/Feed/FeedEdit/FeedEditInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedEdit/FeedEditInteractor.swift
@@ -118,7 +118,12 @@ final class FeedEditInteractor: FeedEditInteractorProtocol {
         guard let isSuccess = response?.data else { return }
 
         if isSuccess {
-          self.presentAlert(message: AlertMessage.feedEditDone.rawValue)
+          self.presentAlert(
+            message: AlertMessage.feedEditDone.rawValue,
+            confirmAction: {
+              self.popFeedEditView()
+            }
+          )
 
         } else {
           self.presentAlert(message: AlertMessage.feedEditFailed.rawValue)

--- a/KnockKnock-iOS/Scenes/Feed/FeedEdit/FeedEditInteractor.swift
+++ b/KnockKnock-iOS/Scenes/Feed/FeedEdit/FeedEditInteractor.swift
@@ -200,7 +200,7 @@ extension FeedEditInteractor {
         Promotion(
           id: 0,
           type: "없음",
-          isSelected: self.promotions.count == 0
+          isSelected: selectedPromotions.count == 0
         ), at: 0
       )
 


### PR DESCRIPTION
## What is this PR?
- 피드 수정 완료 후 이전 화면으로 돌아가지 않는 문제를 해결하였습니다.
- 피드 수정시 해당 게시글에 선택된 프로모션이 없는 경우에 '없음'에 선택 되어있도록 수정하였습니다.

## Changes
- '없음' 옵션의 선택 여부를 결정하는 로직을 수정하였습니다.
- 피드 수정 알럿 창의 확인 버튼의 액션을 추가하였습니다.

## Test Checklist
- none.